### PR TITLE
🐛 Fix: 워크스페이스 입장 시 userRole localStorage 누락

### DIFF
--- a/src/main/resources/static/workspace-list.html
+++ b/src/main/resources/static/workspace-list.html
@@ -91,7 +91,7 @@
             const card = document.createElement('div');
             card.className = 'ws-card';
             card.innerHTML = `
-                    <div onclick="enterWorkspace(${ws.workspaceId})" style="flex-grow:1;">
+                    <div onclick="enterWorkspace(${ws.workspaceId}, '${ws.role}')" style="flex-grow:1;">
                         <div style="font-weight:700; font-size:1.1rem;">${ws.role === 'ADMIN' ? '👑' : '👤'} ${ws.workspaceName}</div>
                         <div style="font-size:0.85rem; color:#94a3b8; margin-top:8px;">클릭하여 입장</div>
                     </div>
@@ -126,7 +126,11 @@
         if ((await res.json()).success) { loadMyWorkspaces(); loadInvitations(); }
     }
 
-    function enterWorkspace(id) { localStorage.setItem('currentWorkspaceId', id); location.href = '/upload.html'; }
+    function enterWorkspace(id, role) {
+        localStorage.setItem('currentWorkspaceId', id);
+        localStorage.setItem('userRole', role);
+        location.href = '/upload.html';
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## ❓이슈
- close #22

## :memo: Description
workspace-list.html의 enterWorkspace 함수에서 워크스페이스 입장 시 userRole이 localStorage에 저장되지 않아 승인/반려 버튼이 비활성화되는 버그를 수정했습니다.

- enterWorkspace(id) → enterWorkspace(id, role) 로 변경
- localStorage.setItem('userRole', role) 추가
- 카드 onclick에 ws.role 인자 추가

## :cyclone: PR Type
- [x] 버그 수정

## :white_check_mark: Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인