### PR TITLE
🐛 Fix: 중복 영수증 안내 메시지 및 userId 저장 처리

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -5,6 +5,7 @@ import com.example.backend.audit.AuditLogService;
 import com.example.backend.domain.receipt.ReceiptStatus;
 import com.example.backend.dto.ReceiptSummaryDto;
 import com.example.backend.dto.ReceiptUpdateRequest;
+import com.example.backend.dto.UploadReceiptResponse;
 import com.example.backend.entity.Receipt;
 import com.example.backend.global.common.ApiResponse;
 import com.example.backend.service.ReceiptService;
@@ -69,7 +70,7 @@ public class ReceiptController {
                   - workspaceId는 query parameter입니다.
                   """)
   @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<ApiResponse<Receipt>> upload(
+  public ResponseEntity<ApiResponse<UploadReceiptResponse>> upload(
       @Parameter(description = "멱등 처리용 키(없으면 서버에서 자동 생성)")
           @RequestHeader(value = "X-IDEMPOTENCY-KEY", required = false)
           String idempotencyKey,
@@ -87,8 +88,8 @@ public class ReceiptController {
             ? "auto-" + UUID.randomUUID()
             : idempotencyKey;
 
-    Receipt receipt = receiptService.uploadAndProcess(key, file, workspaceId);
-    return ResponseEntity.ok(ApiResponse.ok(receipt));
+    UploadReceiptResponse response = receiptService.uploadAndProcess(key, file, workspaceId);
+    return ResponseEntity.ok(ApiResponse.ok(response));
   }
 
   @Operation(
@@ -160,7 +161,7 @@ public class ReceiptController {
                   - request body 있음(files).
                   """)
   @PostMapping(value = "/upload/multiple", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<ApiResponse<List<Receipt>>> uploadMultiple(
+  public ResponseEntity<ApiResponse<List<UploadReceiptResponse>>> uploadMultiple(
       @Parameter(description = "업로드할 영수증 파일 목록", required = true) @RequestPart("files")
           List<MultipartFile> files,
       @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam("workspaceId")

--- a/src/main/java/com/example/backend/dto/LoginResponse.java
+++ b/src/main/java/com/example/backend/dto/LoginResponse.java
@@ -9,4 +9,5 @@ public record LoginResponse(
     @Schema(description = "사용자 이메일", example = "user@example.com") String email,
     @Schema(description = "사용자 이름", example = "둘리") String name,
     @Schema(description = "소속 워크스페이스 개수", example = "2") int workspaceCount,
-    @Schema(description = "마지막 워크스페이스 ID", example = "1") Long lastWorkspaceId) {}
+    @Schema(description = "마지막 워크스페이스 ID", example = "1") Long lastWorkspaceId,
+    @Schema(description = "사용자 ID", example = "1") Long userId) {}

--- a/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
@@ -37,4 +37,6 @@ public class ReceiptSummaryDto {
 
   @Schema(description = "반려 사유", example = "영수증 정보가 불명확합니다.")
   private String rejectionReason;
+
+  private Long userId;
 }

--- a/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
+++ b/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
@@ -1,0 +1,15 @@
+package com.example.backend.dto;
+
+import com.example.backend.entity.Receipt;
+import lombok.Getter;
+
+@Getter
+public class UploadReceiptResponse {
+  private final Receipt receipt;
+  private final boolean isDuplicate;
+
+  public UploadReceiptResponse(Receipt receipt, boolean isDuplicate) {
+    this.receipt = receipt;
+    this.isDuplicate = isDuplicate;
+  }
+}

--- a/src/main/java/com/example/backend/global/error/ErrorCode.java
+++ b/src/main/java/com/example/backend/global/error/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
   AUDIT_ALREADY_DECIDED(HttpStatus.BAD_REQUEST, "이미 승인 또는 반려된 영수증은 수정할 수 없습니다."),
   REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "영수증 반려 시 사유 입력은 필수입니다."),
+  RECEIPT_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 영수증입니다."),
 
   FILE_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다."),
   FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 용량이 너무 큽니다."),

--- a/src/main/java/com/example/backend/service/AuthService.java
+++ b/src/main/java/com/example/backend/service/AuthService.java
@@ -59,7 +59,7 @@ public class AuthService {
     }
 
     String token = jwtTokenProvider.createToken(user.getEmail());
-    return new LoginResponse(token, user.getEmail(), user.getName(), 0, null);
+    return new LoginResponse(token, user.getEmail(), user.getName(), 0, null, user.getId());
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -5,6 +5,7 @@ import com.example.backend.audit.AuditLogService;
 import com.example.backend.domain.receipt.ReceiptStatus;
 import com.example.backend.domain.receipt.SystemErrorCode;
 import com.example.backend.dto.ReceiptSummaryDto;
+import com.example.backend.dto.UploadReceiptResponse;
 import com.example.backend.entity.Receipt;
 import com.example.backend.global.error.BusinessException;
 import com.example.backend.global.error.ErrorCode;
@@ -24,6 +25,7 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -71,52 +73,50 @@ public class ReceiptService {
   }
 
   @Transactional
-  public Receipt uploadAndProcess(String idempotencyKey, MultipartFile file, Long workspaceId) {
+  public UploadReceiptResponse uploadAndProcess(
+      String idempotencyKey, MultipartFile file, Long workspaceId) {
 
     final Long userId = getCurrentUserId();
-
     validateFile(file);
     try {
       byte[] fileBytes = file.getBytes();
       byte[] hashBytes = MessageDigest.getInstance("MD5").digest(fileBytes);
       String fileHash = HexFormat.of().formatHex(hashBytes);
 
-      return receiptRepository
-          .findByFileHash(fileHash)
-          .orElseGet(
-              () ->
-                  receiptRepository
-                      .findByIdempotencyKey(idempotencyKey)
-                      .orElseGet(
-                          () -> {
-                            String savedFileName = null;
-                            Receipt receipt = null;
-                            try {
-                              savedFileName = saveFileToLocal(file);
-                              receipt =
-                                  receiptRepository.save(
-                                      Receipt.builder()
-                                          .idempotencyKey(idempotencyKey)
-                                          .fileHash(fileHash)
-                                          .workspaceId(workspaceId)
-                                          .userId(userId)
-                                          .status(ReceiptStatus.ANALYZING)
-                                          .filePath(savedFileName)
-                                          .build());
-                              log.info(
-                                  "=== [검증 1] DB 선저장 완료: ID={}, Status={}",
-                                  receipt.getId(),
-                                  receipt.getStatus());
-                              JsonNode ocrJson = googleOcrClient.recognize(fileBytes);
-                              log.info("=== [검증 2] OCR 분석 시작 (ID: {})", receipt.getId());
-                              return processOcrResult(receipt, ocrJson);
-                            } catch (Exception e) {
-                              log.error("OCR 분석 에러", e);
-                              if (receipt != null) return markAsFailed(receipt, e);
-                              return saveFailedReceipt(
-                                  idempotencyKey, fileHash, workspaceId, savedFileName, e);
-                            }
-                          }));
+      Optional<Receipt> existingByHash = receiptRepository.findByFileHash(fileHash);
+      if (existingByHash.isPresent()) {
+        return new UploadReceiptResponse(existingByHash.get(), true);
+      }
+
+      Optional<Receipt> existingByKey = receiptRepository.findByIdempotencyKey(idempotencyKey);
+      if (existingByKey.isPresent()) {
+        return new UploadReceiptResponse(existingByKey.get(), true);
+      }
+
+      String savedFileName = null;
+      Receipt receipt = null;
+      try {
+        savedFileName = saveFileToLocal(file);
+        receipt =
+            receiptRepository.save(
+                Receipt.builder()
+                    .idempotencyKey(idempotencyKey)
+                    .fileHash(fileHash)
+                    .workspaceId(workspaceId)
+                    .userId(userId)
+                    .status(ReceiptStatus.ANALYZING)
+                    .filePath(savedFileName)
+                    .build());
+        log.info("=== [검증 1] DB 선저장 완료: ID={}, Status={}", receipt.getId(), receipt.getStatus());
+        JsonNode ocrJson = googleOcrClient.recognize(fileBytes);
+        log.info("=== [검증 2] OCR 분석 시작 (ID: {})", receipt.getId());
+        return new UploadReceiptResponse(processOcrResult(receipt, ocrJson), false);
+      } catch (Exception e) {
+        log.error("OCR 분석 에러", e);
+        if (receipt != null) return new UploadReceiptResponse(markAsFailed(receipt, e), false);
+        return new UploadReceiptResponse(
+            saveFailedReceipt(idempotencyKey, fileHash, workspaceId, savedFileName, e), false);
+      }
     } catch (Exception e) {
       throw new RuntimeException("FILE_PROCESSING_FAILED", e);
     }
@@ -295,7 +295,8 @@ public class ReceiptService {
                   r.getStatus(),
                   ownerName,
                   r.getTags(),
-                  r.getRejectionReason());
+                  r.getRejectionReason(),
+                  r.getUserId());
             })
         .collect(Collectors.toList());
   }
@@ -366,7 +367,7 @@ public class ReceiptService {
   }
 
   @Transactional
-  public List<Receipt> uploadMultiple(List<MultipartFile> files, Long workspaceId) {
+  public List<UploadReceiptResponse> uploadMultiple(List<MultipartFile> files, Long workspaceId) {
     return files.stream()
         .map(
             file -> {

--- a/src/main/resources/static/signin.html
+++ b/src/main/resources/static/signin.html
@@ -50,10 +50,12 @@
                 const token = result.accessToken || (result.data && result.data.accessToken);
                 const userEmail = result.email || (result.data && result.data.email);
                 const userName = result.name || (result.data && result.data.name);
+                const userId = result.userId || (result.data && result.data.userId);
 
                 localStorage.setItem('accessToken', token);
                 localStorage.setItem('userEmail', userEmail);
                 localStorage.setItem('userName', userName);
+                localStorage.setItem('currentUserId', userId);
 
                 alert(userName + "님, 환영합니다!");
                 location.href = "/";

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -291,7 +291,13 @@
             });
             el('progBar').style.width = '100%';
             if (res.ok) {
-                alert("분석 완료!");
+                const json = await res.json();
+                const hasDuplicate = json.data && json.data.some(r => r.duplicate);
+                if (hasDuplicate) {
+                    alert("이미 등록된 영수증이 포함되어 있습니다.");
+                } else {
+                    alert("분석 완료!");
+                }
                 el('fileInput').value = '';
                 el('thumbs').innerHTML = '';
                 el('thumbs').style.display = 'none';


### PR DESCRIPTION
## ❓이슈
- close #23

## :memo: Description
중복 영수증 업로드 시 안내 메시지 누락 및 수정 버튼 활성화 오작동 버그를 수정했습니다.

[중복 영수증 안내 메시지]
- 백엔드가 중복 감지 시 기존 영수증 객체를 그대로 반환하여
  프론트가 신규/중복 응답을 구분할 수 없었던 문제 수정
- UploadReceiptResponse DTO 추가로 isDuplicate 플래그 명시적 반환

[수정 버튼 활성화 오작동]
- JavaScript == 연산자가 undefined와 null을 동일하게 처리하여
  모든 영수증 수정 버튼이 활성화되던 문제 수정
- LoginResponse에 userId 추가 및 로그인 시 localStorage 저장으로 해결

## :cyclone: PR Type
- [x] 버그 수정

## :white_check_mark: Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인