### PR TITLE
✨ Feat: 영수증 상태 전이 정리 및 에러코드 강화

### DIFF
--- a/src/main/java/com/example/backend/audit/AuditAction.java
+++ b/src/main/java/com/example/backend/audit/AuditAction.java
@@ -6,7 +6,6 @@ public enum AuditAction {
   CLAIM,
   APPROVE,
   REJECT,
-  RESUBMIT,
   DOWNLOAD,
   SELF_APPROVE,
   LOGIN,

--- a/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
+++ b/src/main/java/com/example/backend/domain/receipt/ReceiptStatus.java
@@ -18,7 +18,7 @@ public enum ReceiptStatus {
           ANALYZING, List.of(WAITING, NEED_MANUAL, FAILED_SYSTEM),
           WAITING, List.of(APPROVED, REJECTED, EXPIRED),
           NEED_MANUAL, List.of(WAITING, APPROVED, REJECTED),
-          REJECTED, List.of(WAITING),
+          REJECTED, List.of(),
           FAILED_SYSTEM, List.of(ANALYZING),
           APPROVED, List.of());
 

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -55,6 +55,7 @@ public class Receipt {
   private Long userId;
 
   private String rejectionReason;
+  private LocalDateTime approvedAt;
 
   @ElementCollection(fetch = FetchType.LAZY)
   @CollectionTable(name = "receipt_tags", joinColumns = @JoinColumn(name = "receipt_id"))
@@ -105,7 +106,7 @@ public class Receipt {
   public void updateStatus(ReceiptStatus status, String reason, Long actorUserId) {
 
     if (!this.status.canTransitionTo(status)) {
-      throw ErrorCode.INVALID_REQUEST.toException("상태 변경이 불가능한 단계입니다.");
+      throw ErrorCode.INVALID_STATE_TRANSITION.toException();
     }
 
     if (status == ReceiptStatus.REJECTED && (reason == null || reason.isBlank())) {
@@ -113,14 +114,18 @@ public class Receipt {
     }
 
     this.status = status;
+    if (status == ReceiptStatus.APPROVED) {
+      this.approvedAt = LocalDateTime.now();
+    }
     if (status == ReceiptStatus.REJECTED) {
       this.rejectionReason = reason;
     }
   }
 
   public void updateInfo(Integer totalAmount, String storeName, LocalDateTime tradeAt) {
-    if (this.status == ReceiptStatus.APPROVED) {
-      throw new IllegalStateException("이미 승인된 영수증은 수정할 수 없습니다.");
+    if (this.status != ReceiptStatus.ANALYZING && this.status != ReceiptStatus.NEED_MANUAL) {
+      throw ErrorCode.INVALID_STATE_TRANSITION.toException(
+          "수정은 ANALYZING 또는 NEED_MANUAL 상태에서만 가능합니다.");
     }
 
     if (totalAmount != null) {
@@ -134,19 +139,5 @@ public class Receipt {
       this.nightTime = (tradeAt.getHour() >= 23 || tradeAt.getHour() < 6);
     }
     this.systemErrorCode = null;
-  }
-
-  public void resubmit() {
-
-    if (this.status != ReceiptStatus.REJECTED) {
-      throw new IllegalStateException("반려된 영수증만 재제출이 가능합니다.");
-    }
-
-    if (!this.status.canTransitionTo(ReceiptStatus.WAITING)) {
-      throw new IllegalStateException("INVALID_STATE_TRANSITION");
-    }
-
-    this.status = ReceiptStatus.WAITING;
-    this.rejectionReason = null;
   }
 }

--- a/src/main/java/com/example/backend/global/error/ErrorCode.java
+++ b/src/main/java/com/example/backend/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
   AUDIT_ALREADY_DECIDED(HttpStatus.BAD_REQUEST, "이미 승인 또는 반려된 영수증은 수정할 수 없습니다."),
   REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "영수증 반려 시 사유 입력은 필수입니다."),
   RECEIPT_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 영수증입니다."),
+  INVALID_STATE_TRANSITION(HttpStatus.CONFLICT, "허용되지 않는 상태 전이입니다."),
 
   FILE_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다."),
   FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "파일 용량이 너무 큽니다."),

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -252,12 +252,6 @@ public class ReceiptService {
 
     Receipt receipt = getReceiptSecurely(id, workspaceId);
 
-    if (receipt.getStatus() == ReceiptStatus.APPROVED
-        || receipt.getStatus() == ReceiptStatus.REJECTED) {
-      throw new com.example.backend.global.error.BusinessException(
-          com.example.backend.global.error.ErrorCode.AUDIT_ALREADY_DECIDED);
-    }
-
     ReceiptStatus oldStatus = receipt.getStatus();
 
     receipt.updateInfo(totalAmount, storeName, tradeAt);


### PR DESCRIPTION
## ❓이슈
- close #30

## :memo: Description
영수증 상태 전이 규칙을 실사용 수준으로 정리하고 에러코드를 강화했습니다.

- REJECTED 재제출 전이 제거 (반려 = 종착점으로 정책 확정)
- 상태 전이 실패 시 INVALID_STATE_TRANSITION 에러코드로 분리
- 수동 수정 조건 변경 (ANALYZING, NEED_MANUAL 상태에서 허용)
- resubmit() 메서드 및 RESUBMIT AuditAction 삭제
- approvedAt 필드 추가 및 APPROVED 전이 시 자동 저장

## :cyclone: PR Type
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## :white_check_mark: Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인