### PR TITLE
✨ Feat: 영수증 업로드 플로우 변경 및 API 경로 통일

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -26,7 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/receipts")
+@RequestMapping("/api/v1/receipts")
 @RequiredArgsConstructor
 @CrossOrigin(origins = "*")
 @Tag(name = "Receipt", description = "영수증 조회, 업로드, 수정, 상태 변경, 이력, 통계를 관리합니다.")
@@ -185,5 +185,22 @@ public class ReceiptController {
   public ResponseEntity<ApiResponse<Map<String, Object>>> getStats(
       @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
     return ResponseEntity.ok(ApiResponse.ok(receiptService.getAdminStats(workspaceId)));
+  }
+
+  @Operation(summary = "영수증 삭제", description = "업로드 취소 시 영수증을 삭제합니다.")
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void>> deleteReceipt(
+      @Parameter(description = "영수증 ID", example = "1") @PathVariable Long id,
+      @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
+    receiptService.deleteReceipt(id, workspaceId);
+    return ResponseEntity.ok(ApiResponse.ok(null));
+  }
+
+  @Operation(summary = "영수증 저장 확정", description = "미리보기 후 저장 버튼 클릭 시 WAITING으로 전이합니다.")
+  @PatchMapping("/{id}/confirm")
+  public ResponseEntity<ApiResponse<Receipt>> confirmReceipt(
+      @Parameter(description = "영수증 ID", example = "1") @PathVariable Long id,
+      @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
+    return ResponseEntity.ok(ApiResponse.ok(receiptService.confirmReceipt(id, workspaceId)));
   }
 }

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -147,4 +147,12 @@ public class Receipt {
     }
     this.systemErrorCode = null;
   }
+
+  public void confirm() {
+    if (this.status != ReceiptStatus.ANALYZING && this.status != ReceiptStatus.NEED_MANUAL) {
+      throw ErrorCode.INVALID_STATE_TRANSITION.toException(
+          "저장 확정은 ANALYZING 또는 NEED_MANUAL 상태에서만 가능합니다.");
+    }
+    this.status = ReceiptStatus.WAITING;
+  }
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -422,4 +422,18 @@ public class ReceiptService {
   public java.util.Map<String, Object> getAdminStats(Long workspaceId) {
     return receiptRepository.getWorkspaceStats(workspaceId);
   }
+
+  @Transactional
+  public void deleteReceipt(Long id, Long workspaceId) {
+    Receipt receipt = getReceiptSecurely(id, workspaceId);
+    receiptItemRepository.deleteAll(receiptItemRepository.findAllByReceiptId(id));
+    receiptRepository.delete(receipt);
+  }
+
+  @Transactional
+  public Receipt confirmReceipt(Long id, Long workspaceId) {
+    Receipt receipt = getReceiptSecurely(id, workspaceId);
+    receipt.confirm();
+    return receipt;
+  }
 }

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -206,14 +206,14 @@
         const isReallyAdmin = window.checkIsAdmin();
 
         try {
-            const res = await fetch(`/api/receipts?workspaceId=${workspaceId}`, {
+            const res = await fetch(`/api/v1/receipts?workspaceId=${workspaceId}`,  {
                 headers: { 'Authorization': `Bearer ${token}` }
             });
             const json = await res.json();
             receiptData = json.data;
 
             if (isReallyAdmin) {
-                fetch(`/api/receipts/stats?workspaceId=${workspaceId}`, {
+                fetch(`/api/v1/receipts/stats?workspaceId=${workspaceId}`, {
                     headers: { 'Authorization': `Bearer ${token}` }
                 })
                     .then(res => res.json())
@@ -284,7 +284,7 @@
 
         try {
             el('progBar').style.width = '60%';
-            const res = await fetch(`/api/receipts/upload/multiple?workspaceId=${workspaceId}`, {
+            const res = await fetch(`/api/v1/receipts/upload/multiple?workspaceId=${workspaceId}`, {
                 method: 'POST',
                 headers: { 'Authorization': `Bearer ${token}` },
                 body: formData
@@ -319,7 +319,7 @@
 
     function exportCSV() {
         const params = new URLSearchParams({ workspaceId });
-        window.location.href = `/api/receipts/export?${params}`;
+        window.location.href = `/api/v1/receipts/export?${params}`;
     }
     async function updateStatus(id, status) {
         let reason = "관리자 요청";
@@ -337,7 +337,7 @@
         }
         try {
             const params = new URLSearchParams({ workspaceId, status, reason });
-            const res = await fetch(`/api/receipts/${id}/status?${params}`, {
+            const res = await fetch(`/api/v1/receipts/${id}/status?${params}`, {
                 method: 'PATCH',
                 headers: { 'Authorization': `Bearer ${token}` }
             });
@@ -393,7 +393,7 @@
         };
         try {
             const params = new URLSearchParams({ workspaceId });
-            const res = await fetch(`/api/receipts/${id}?${params}`, {
+            const res = await fetch(`/api/v1/receipts/${id}?${params}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
                 body: JSON.stringify(body)
@@ -405,7 +405,7 @@
     async function showHistory(id) {
         const token = localStorage.getItem('accessToken');
         try {
-            const res = await fetch(`/api/receipts/${id}/history`, {
+            const res = await fetch(`/api/v1/receipts/${id}/history`, {
                 headers: { 'Authorization': `Bearer ${token}` }
             });
             const json = await res.json();


### PR DESCRIPTION
## ❓이슈
- close #32

## :memo: Description
- ReceiptController.java — @RequestMapping `/api/v1/receipts`로 통일
- DELETE /{id} API 추가 (업로드 취소)
- PATCH /{id}/confirm API 추가 (저장 확정 → WAITING 전이)
- Receipt.java — confirm() 메서드 추가
- ReceiptService.java — deleteReceipt(), confirmReceipt() 추가
- upload.html — API 경로 전체 /api/v1/receipts로 수정

## :cyclone: PR Type
- [x] 새로운 기능 추가

## :white_check_mark: Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인

## 📸 스크린샷
**PATCH /confirm - 저장 확정 (ANALYZING → WAITING)**
<img width="1444" height="587" alt="image" src="https://github.com/user-attachments/assets/e6137acf-75fd-4cb9-a76b-113f8b0fa0cf" />

**DELETE /{id} - 업로드 취소**
<img width="1261" height="477" alt="image" src="https://github.com/user-attachments/assets/df3364cd-c4f2-49e9-929a-1b1b0be3050b" />