### PR TITLE
🐛 Fix: 워크스페이스 구분 없이 중복 영수증 감지되는 버그

### DIFF
--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -39,7 +39,7 @@ public class Receipt {
   @Column(unique = true)
   private String idempotencyKey;
 
-  @Column(name = "file_hash", unique = true)
+  @Column(name = "file_hash")
   private String fileHash;
 
   private String filePath;

--- a/src/main/java/com/example/backend/repository/ReceiptRepository.java
+++ b/src/main/java/com/example/backend/repository/ReceiptRepository.java
@@ -15,6 +15,8 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
 
   Optional<Receipt> findByFileHash(String fileHash);
 
+  Optional<Receipt> findByFileHashAndWorkspaceId(String fileHash, Long workspaceId);
+
   List<Receipt> findAllByUserId(Long userId);
 
   Optional<Receipt> findByIdAndUserId(Long id, Long userId);

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -86,7 +86,8 @@ public class ReceiptService {
       byte[] hashBytes = MessageDigest.getInstance("MD5").digest(fileBytes);
       String fileHash = HexFormat.of().formatHex(hashBytes);
 
-      Optional<Receipt> existingByHash = receiptRepository.findByFileHash(fileHash);
+      Optional<Receipt> existingByHash =
+          receiptRepository.findByFileHashAndWorkspaceId(fileHash, workspaceId);
       if (existingByHash.isPresent()) {
         return new UploadReceiptResponse(existingByHash.get(), true);
       }


### PR DESCRIPTION
## ❓이슈
- close #34

## 📝 Description
- Receipt.java — file_hash 컬럼의 unique 제약 제거
  (다른 워크스페이스에서 동일 파일 업로드 허용)
- ReceiptRepository.java — findByFileHashAndWorkspaceId() 추가
- ReceiptService.java — 중복 감지 로직을 workspaceId 포함으로 변경
  (같은 워크스페이스 내에서만 중복으로 처리)

## 🌀 PR Type
- [x] 버그 수정

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인