### PR TITLE
♻️ refactor: Gemini 2.0 Flash → 2.5 Flash 모델 업그레이드

### DIFF
--- a/src/main/java/com/example/backend/ocr/GeminiService.java
+++ b/src/main/java/com/example/backend/ocr/GeminiService.java
@@ -21,7 +21,7 @@ public class GeminiService {
   private final RestTemplate restTemplate = new RestTemplate();
 
   public JsonNode getParsedReceipt(String rawText) {
-    String model = "models/gemini-2.0-flash";
+    String model = "models/gemini-2.5-flash";
     String url =
         "https://generativelanguage.googleapis.com/v1beta/"
             + model


### PR DESCRIPTION
## ❓이슈
- close #55

## 📝 Description
- GeminiService.java — 모델명 변경
  `models/gemini-2.0-flash` → `models/gemini-2.5-flash`
- gemini-2.0-flash 모델이 2026년 6월 1일 지원 종료 예정으로 사전 업그레이드

## 🌀 PR Type
- [x] 코드 리팩토링

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인