### PR TITLE
✨ feat: 영수증 목록 조회 응답에 createdAt(게시일) 추가 및 정렬 기준 변경

### DIFF
--- a/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
@@ -41,4 +41,5 @@ public class ReceiptSummaryDto {
   private Long userId;
   private Integer tax;
   private Double confidence;
+  private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -309,7 +309,8 @@ public class ReceiptService {
                   r.getRejectionReason(),
                   r.getUserId(),
                   r.getTax(),
-                  r.getConfidence());
+                  r.getConfidence(),
+                  r.getCreatedAt());
             })
         .collect(Collectors.toList());
   }

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -285,9 +285,9 @@
         });
 
         if (sort === 'oldest') {
-            filtered.sort((a, b) => new Date(a.tradeAt) - new Date(b.tradeAt));
+            filtered.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
         } else {
-            filtered.sort((a, b) => new Date(b.tradeAt) - new Date(a.tradeAt));
+            filtered.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
         }
 
         receiptData = filtered;
@@ -297,13 +297,13 @@
     function renderReceipts() {
         const statusLabel = { WAITING: '대기', ANALYZING: '대기', NEED_MANUAL: '대기', APPROVED: '승인', REJECTED: '반려', FAILED_SYSTEM: '오류' };
         const html = receiptData.map(r => {
-            const tradeAt = r.tradeAt ? r.tradeAt.replace('T', ' ').substring(0, 10) : '-';
+            const createdAt = r.createdAt ? r.createdAt.replace('T', ' ').substring(0, 10) : '-';
             return `<tr onclick="location.href='/receipt-detail.html?id=${r.id}&workspaceId=${workspaceId}'">
                 <td>${escapeHtml(r.userName || '-')}</td>
                 <td><strong>${escapeHtml(r.storeName || '-')}</strong></td>
                 <td>₩${(r.totalAmount || 0).toLocaleString()}</td>
                 <td><span class="status-badge ${r.status}"><span class="dot"></span>${statusLabel[r.status] || r.status}</span></td>
-                <td style="color:#64748b;">${tradeAt}</td>
+                <td style="color:#64748b;">${createdAt}</td>
             </tr>`;
         }).join('');
         el('receiptList').innerHTML = html || '<tr><td colspan="5" style="text-align:center;padding:40px;color:#94a3b8;">데이터가 없습니다.</td></tr>';


### PR DESCRIPTION
## ❓이슈
- close #58

## 📝 Description
- ReceiptSummaryDto.java — createdAt 필드 추가
- ReceiptService.java — getWorkspaceReceipts() 응답에 createdAt 매핑 추가
- upload.html — 게시일 표시 tradeAt → createdAt 변경
- upload.html — 정렬 기준 tradeAt → createdAt 변경 및 최신순/오래된순 버그 수정

## 🌀 PR Type
- [x] 새로운 기능 추가

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인