### PR TITLE
✨ feat: Receipt 엔티티 부적절 판정 필드 추가

### DIFF
--- a/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
@@ -54,4 +54,13 @@ public class ReceiptDetailDto {
 
   @Schema(description = "야간 여부")
   private boolean nightTime;
+
+  @Schema(description = "부적절 판정 사유 목록", nullable = true)
+  private List<String> inappropriateReasons;
+
+  @Schema(description = "할인 금액", example = "1000", nullable = true)
+  private Integer discountAmount;
+
+  @Schema(description = "AI 추천 반려 사유", nullable = true)
+  private String aiReason;
 }

--- a/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptSummaryDto.java
@@ -42,4 +42,7 @@ public class ReceiptSummaryDto {
   private Integer tax;
   private Double confidence;
   private LocalDateTime createdAt;
+  private List<String> inappropriateReasons;
+  private Integer discountAmount;
+  private String aiReason;
 }

--- a/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
+++ b/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
@@ -57,4 +57,13 @@ public class UploadReceiptResponse {
 
   @Schema(description = "중복 업로드 여부", example = "false")
   private boolean isDuplicate;
+
+  @Schema(description = "부적절 판정 사유 목록", nullable = true)
+  private List<String> inappropriateReasons;
+
+  @Schema(description = "할인 금액", example = "1000", nullable = true)
+  private Integer discountAmount;
+
+  @Schema(description = "AI 추천 반려 사유", nullable = true)
+  private String aiReason;
 }

--- a/src/main/java/com/example/backend/entity/Receipt.java
+++ b/src/main/java/com/example/backend/entity/Receipt.java
@@ -66,11 +66,36 @@ public class Receipt {
   @Builder.Default
   private java.util.List<String> tags = new java.util.ArrayList<>();
 
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "receipt_inappropriate_reasons",
+      joinColumns = @JoinColumn(name = "receipt_id"))
+  @Column(name = "reason")
+  @Builder.Default
+  private java.util.List<String> inappropriateReasons = new java.util.ArrayList<>();
+
+  private Integer discountAmount;
+
+  @Column(length = 500)
+  private String aiReason;
+
   public void updateTags(java.util.List<String> newTags) {
     this.tags.clear();
     if (newTags != null) {
       this.tags.addAll(newTags);
     }
+  }
+
+  public void updateInappropriateReasons(java.util.List<String> reasons) {
+    this.inappropriateReasons.clear();
+    if (reasons != null) {
+      this.inappropriateReasons.addAll(reasons);
+    }
+  }
+
+  public void updateDiscountAndReason(Integer discountAmount, String aiReason) {
+    this.discountAmount = discountAmount;
+    this.aiReason = aiReason;
   }
 
   private LocalDateTime createdAt;

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -423,7 +423,10 @@ public class ReceiptService {
                   r.getUserId(),
                   r.getTax(),
                   r.getConfidence(),
-                  r.getCreatedAt());
+                  r.getCreatedAt(),
+                  r.getInappropriateReasons(),
+                  r.getDiscountAmount(),
+                  r.getAiReason());
             })
         .collect(Collectors.toList());
   }
@@ -563,7 +566,10 @@ public class ReceiptService {
         receipt.getFilePath(),
         receipt.getTags(),
         items,
-        receipt.isNightTime());
+        receipt.isNightTime(),
+        receipt.getInappropriateReasons(),
+        receipt.getDiscountAmount(),
+        receipt.getAiReason());
   }
 
   public ReceiptActionResponseDto toReceiptActionResponse(Receipt receipt) {
@@ -604,6 +610,9 @@ public class ReceiptService {
         .tags(receipt.getTags())
         .createdAt(receipt.getCreatedAt())
         .isDuplicate(isDuplicate)
+        .inappropriateReasons(receipt.getInappropriateReasons())
+        .discountAmount(receipt.getDiscountAmount())
+        .aiReason(receipt.getAiReason())
         .build();
   }
 


### PR DESCRIPTION
## ❓이슈
- close #67

## 📝 Description

### 추가 배경
팀 회의 결과 부적절 판정(심야결제, 공휴일, 유흥업소, 쪼개기결제) 및 할인금액 표시 기능 구현이 결정됨
이를 위해 판정 결과를 저장하고 프론트에 전달하기 위한 필드를 먼저 추가함

### 변경 내용

**Receipt.java 엔티티 필드 추가**
- inappropriateReasons (List<String>) — 부적절 판정 사유 코드 목록
  별도 테이블(receipt_inappropriate_reasons)로 관리
- discountAmount (Integer) — 할인금액
- aiReason (String, max 500자) — AI 추천 반려 사유 문장

**메서드 추가**
- updateInappropriateReasons() — 부적절 사유 목록 업데이트
- updateDiscountAndReason() — 할인금액 및 AI 사유 업데이트

**DTO 필드 추가 (3개 DTO 공통)**
- UploadReceiptResponse, ReceiptDetailDto, ReceiptSummaryDto에
  inappropriateReasons, discountAmount, aiReason 필드 추가

**ReceiptService 매핑 수정**
- toUploadReceiptResponse(), getReceiptDetail(), getWorkspaceReceipts()에
  신규 필드 매핑 추가

### 다음 작업 예정
- Gemini 프롬프트에 discountAmount, aiReason 추출 추가
- 부적절 판정 로직 구현 (심야/공휴일/유흥업소/쪼개기결제)
- 권한별 응답 분기 처리 (관리자/본인/일반멤버)

## 🌀 PR Type
- [x] 새로운 기능 추가

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] Swagger API 응답 스펙 확인 (inappropriateReasons, discountAmount, aiReason 추가 확인)
- [x] DB 테이블 생성 확인 (receipt_inappropriate_reasons)

### 1. GET /api/v1/receipts
<img width="414" height="520" alt="image" src="https://github.com/user-attachments/assets/98d518ca-0d4a-44e9-b3dd-615a3687b612" />

### 2. GET /api/v1/receipts/{id}
<img width="406" height="523" alt="image" src="https://github.com/user-attachments/assets/96df8f12-67f5-4630-ad87-78a34e44538a" />

### 3. POST /api/v1/receipts/upload
<img width="411" height="522" alt="image" src="https://github.com/user-attachments/assets/b343249e-ed2d-436f-bd26-5bb9dd572faa" />

### receipt_inappropriate_reasons 테이블 생성 확인
<img width="554" height="514" alt="image" src="https://github.com/user-attachments/assets/cdf64b12-137f-4d94-bcae-03920f83e519" />


