### PR TITLE
✨ feat: ocr 성능 개선

### DIFF
--- a/src/main/java/com/example/backend/ocr/GeminiService.java
+++ b/src/main/java/com/example/backend/ocr/GeminiService.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -14,11 +15,13 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class GeminiService {
 
   @Value("${google.api.key}")
   private String apiKey;
 
+  private final ImagePreprocessor imagePreprocessor;
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final RestTemplate restTemplate = new RestTemplate();
 
@@ -87,36 +90,66 @@ public class GeminiService {
             + "8. aiReason: 이 영수증에 대한 한 줄 분석 의견(한국어).\n"
             + "   - 부적절 의심 요소가 있으면 명시 (예: '주류 판매 업소로 의심됨')\n"
             + "   - 정상이면 '정상 영수증으로 판단됨'\n\n"
-            + "응답 JSON 형식:\n"
-            + "{\n"
-            + "  \"storeName\": \"가맹점명\",\n"
-            + "  \"totalAmount\": 숫자,\n"
-            + "  \"tradeAt\": \"YYYY-MM-DD HH:mm:ss\",\n"
-            + "  \"confidence\": 숫자,\n"
-            + "  \"discountAmount\": 숫자,\n"
-            + "  \"category\": \"업종코드\",\n"
-            + "  \"aiReason\": \"한 줄 분석 의견\",\n"
-            + "  \"items\": [\n"
-            + "    {\"name\": \"상품명\", \"quantity\": 숫자, \"price\": 숫자}\n"
-            + "  ]\n"
-            + "}\n\n"
             + "영수증 OCR 텍스트 (참고용):\n"
             + rawText;
 
     List<Map<String, Object>> parts = new ArrayList<>();
 
     if (imageBytes != null && imageBytes.length > 0) {
-      String base64Image = Base64.getEncoder().encodeToString(imageBytes);
-      parts.add(Map.of("inline_data", Map.of("mime_type", mimeType, "data", base64Image)));
-      log.info("=== 이미지 전송 완료 ({}bytes)", imageBytes.length);
+      byte[] processedBytes = imagePreprocessor.resize(imageBytes);
+      String base64Image = Base64.getEncoder().encodeToString(processedBytes);
+      parts.add(Map.of("inline_data", Map.of("mime_type", "image/jpeg", "data", base64Image)));
+      log.info(
+          "=== 이미지 전송 완료 (원본: {}bytes → 압축: {}bytes)", imageBytes.length, processedBytes.length);
     }
 
     parts.add(Map.of("text", prompt));
 
-    Map<String, Object> body =
+    Map<String, Object> itemSchema =
         Map.of(
-            "contents", List.of(Map.of("parts", parts)),
-            "generationConfig", Map.of("response_mime_type", "application/json"));
+            "type", "OBJECT",
+            "properties",
+                Map.of(
+                    "name", Map.of("type", "STRING"),
+                    "quantity", Map.of("type", "INTEGER"),
+                    "price", Map.of("type", "INTEGER")),
+            "required", List.of("name", "quantity", "price"));
+
+    Map<String, Object> responseSchema =
+        Map.of(
+            "type", "OBJECT",
+            "properties",
+                Map.of(
+                    "storeName", Map.of("type", "STRING"),
+                    "totalAmount", Map.of("type", "INTEGER"),
+                    "tradeAt", Map.of("type", "STRING"),
+                    "confidence", Map.of("type", "NUMBER"),
+                    "discountAmount", Map.of("type", "INTEGER"),
+                    "category", Map.of("type", "STRING"),
+                    "aiReason", Map.of("type", "STRING"),
+                    "items", Map.of("type", "ARRAY", "items", itemSchema)),
+            "required",
+                List.of(
+                    "storeName",
+                    "totalAmount",
+                    "tradeAt",
+                    "confidence",
+                    "discountAmount",
+                    "category",
+                    "aiReason",
+                    "items"));
+
+    Map<String, Object> generationConfig =
+        Map.of(
+            "response_mime_type",
+            "application/json",
+            "temperature",
+            0.0,
+            "response_schema",
+            responseSchema);
+
+    Map<String, Object> body =
+        Map.of("contents", List.of(Map.of("parts", parts)), "generationConfig", generationConfig);
 
     try {
       HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);

--- a/src/main/java/com/example/backend/ocr/ImagePreprocessor.java
+++ b/src/main/java/com/example/backend/ocr/ImagePreprocessor.java
@@ -1,0 +1,68 @@
+package com.example.backend.ocr;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class ImagePreprocessor {
+
+  private static final int MAX_WIDTH = 1200;
+  private static final float JPEG_QUALITY = 0.75f;
+
+  public byte[] resize(byte[] imageBytes) {
+    try {
+      BufferedImage original = ImageIO.read(new ByteArrayInputStream(imageBytes));
+      if (original == null) return imageBytes;
+
+      int originalWidth = original.getWidth();
+      int originalHeight = original.getHeight();
+
+      BufferedImage target;
+      if (originalWidth > MAX_WIDTH) {
+        int newHeight = (int) ((double) originalHeight * MAX_WIDTH / originalWidth);
+        target = new BufferedImage(MAX_WIDTH, newHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = target.createGraphics();
+        g2d.drawImage(original, 0, 0, MAX_WIDTH, newHeight, null);
+        g2d.dispose();
+      } else {
+        target = new BufferedImage(originalWidth, originalHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = target.createGraphics();
+        g2d.drawImage(original, 0, 0, null);
+        g2d.dispose();
+      }
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ImageWriter writer = ImageIO.getImageWritersByFormatName("jpeg").next();
+      ImageWriteParam param = writer.getDefaultWriteParam();
+      param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+      param.setCompressionQuality(JPEG_QUALITY);
+      ImageOutputStream ios = ImageIO.createImageOutputStream(baos);
+      writer.setOutput(ios);
+      writer.write(null, new IIOImage(target, null, null), param);
+      writer.dispose();
+      ios.close();
+
+      byte[] result = baos.toByteArray();
+      log.info(
+          "=== 이미지 압축 완료: {}bytes → {}bytes ({}%)",
+          imageBytes.length,
+          result.length,
+          (int) ((double) result.length / imageBytes.length * 100));
+      return result;
+
+    } catch (Exception e) {
+      log.warn("=== 이미지 압축 실패, 원본 사용: {}", e.getMessage());
+      return imageBytes;
+    }
+  }
+}

--- a/src/main/java/com/example/backend/service/InappropriateReasonService.java
+++ b/src/main/java/com/example/backend/service/InappropriateReasonService.java
@@ -22,7 +22,7 @@ public class InappropriateReasonService {
   private final HolidayService holidayService;
 
   private static final List<String> ENTERTAINMENT_STORE_KEYWORDS =
-      List.of("호프", "포차", "주점", "bar", "바", "클럽", "나이트", "룸살롱", "단란주점", "가라오케", "노래방", "펍");
+      List.of("호프", "포차", "주점", "bar", "클럽", "나이트", "룸살롱", "단란주점", "가라오케", "노래방", "펍");
 
   @Transactional
   public List<String> evaluate(Receipt receipt, String category, Long workspaceId) {
@@ -95,7 +95,21 @@ public class InappropriateReasonService {
   private boolean isEntertainment(String storeName, String category) {
     if (category != null) {
       String cat = category.toUpperCase();
-      if (cat.contains("ENTERTAINMENT") || cat.contains("BAR") || cat.contains("ADULT")) {
+
+      if (cat.equals("FOOD")
+          || cat.equals("SHOPPING")
+          || cat.equals("MEDICAL")
+          || cat.equals("TRANSPORT")
+          || cat.equals("ACCOMMODATION")
+          || cat.equals("OFFICE")
+          || cat.equals("EQUIPMENT")
+          || cat.equals("WELFARE")
+          || cat.equals("SERVICE")
+          || cat.equals("ACTIVITY")) {
+        return false;
+      }
+
+      if (cat.equals("ENTERTAINMENT")) {
         return true;
       }
     }


### PR DESCRIPTION
## ❓이슈
- close #85

## 📝 Description

### 1. temperature=0 고정
**문제:**
Gemini는 LLM 특성상 동일한 입력에도 매번 확률적으로
다른 응답을 생성합니다. 이로 인해 같은 영수증을
두 번 업로드하면 storeName, totalAmount 등이
다르게 추출되는 일관성 문제가 있었습니다.

**해결:**
generationConfig에 temperature=0.0을 추가했습니다.
temperature가 0에 가까울수록 모델은 창의성을 버리고
가장 확률이 높은 사실에만 집중합니다.
→ 동일 영수증 반복 호출 시 일관된 결과 보장

---

### 2. response_schema 강제
**문제:**
기존 방식은 프롬프트 텍스트로 JSON 형식을 설명했습니다.
이 방식은 두 가지 문제가 있었습니다.
1) 모델이 형식을 해석하는 데 불필요한 토큰/시간 소비
2) 가끔 JSON 외 설명 텍스트가 포함되어 파싱 실패 발생

**해결:**
Gemini API의 response_schema 기능을 활용하여
API 레벨에서 출력 구조를 강제했습니다.
→ 모델이 형식 고민 없이 값 추출에만 집중
→ JSON 파싱 실패 케이스 제거
→ 프롬프트 토큰 사용량 감소
→ 응답 속도 개선

---

### 3. 이미지 압축 (ImagePreprocessor 신규 생성)
**문제:**
스마트폰 원본 사진은 수 MB에 달합니다.
이 고용량 이미지를 그대로 Gemini API에 전송하면
네트워크 전송 시간과 AI 이미지 스캔 시간이
비약적으로 늘어납니다. (현재 15~17초)

**해결:**
ImagePreprocessor.java를 새로 만들어
업로드 시 이미지를 전처리합니다.
- 가로 1200px 초과 시 비율 유지하며 리사이징
- JPEG 75% 품질로 압축
- 평균 원본 대비 약 70~80% 용량 감소
→ 목표: 15~17초 → 10~13초

---

### 4. 유흥업소 판정 하이브리드 방식 개선
**문제:**
기존 키워드 기반 필터링은 단순 문자열 contains 방식으로
문맥을 전혀 이해하지 못했습니다.

오탐 사례:
- "파리바게트" → "바" 키워드에 걸려 유흥업소로 오탐
- "스타바" → "바" 키워드에 걸려 유흥업소로 오탐

이는 AI 시스템에서 규칙 기반 필터링의 한계를 보여줍니다.

**해결: Gemini AI + 키워드 하이브리드 방식**
- 1차 판단: Gemini category 활용
→ FOOD/SHOPPING/MEDICAL 등 명확한 정상 카테고리
→ 키워드 검사 없이 바로 정상 처리
→ ENTERTAINMENT
→ 바로 유흥업소 의심 처리

- 2차 판단: 키워드 보완 (ETC/null인 경우만)
→ category가 애매한 경우에만 키워드 체크
→ 오탐 원인인 "바" 키워드 제거

**이 방식의 장점:**
- Gemini가 문맥을 이해하여 분류한 결과를 1차로 신뢰
- 애매한 경우에만 규칙 기반으로 보완
- "AI 판단 + 규칙 기반 안전망" 계층적 검증 구조
- 오탐률 감소 + 정확도 향상

## 🌀 PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 파리바게트 → 정상 처리 확인 (오탐 제거)
- [x] 유흥업소 영수증 → 의심 태그 정상 부착 확인
- [x] 동일 영수증 반복 업로드 시 일관된 결과 확인
- [x] 이미지 압축 로그 확인 (원본 → 압축 bytes)
- [x] CI 테스트 통과