### PR TITLE
🐛 fix: ocr 날짜 금액 버그수정

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -439,7 +439,7 @@ public class ReceiptController {
                   tradeAtValue, java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
               : LocalDateTime.now();
     } catch (Exception e) {
-      tradeAt = LocalDateTime.now();
+      return ResponseEntity.badRequest().build();
     }
 
     return ResponseEntity.ok(

--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -430,6 +430,17 @@ public class ReceiptController {
     String storeName = request.getStoreName();
     Integer totalAmount = request.getTotalAmount();
     String tradeAtValue = request.getTradeAt();
+
+    if (storeName == null || storeName.isBlank()) {
+      return ResponseEntity.badRequest().build();
+    }
+    if (totalAmount == null || totalAmount <= 0) {
+      return ResponseEntity.badRequest().build();
+    }
+    if (tradeAtValue == null || tradeAtValue.isBlank()) {
+      return ResponseEntity.badRequest().build();
+    }
+
     LocalDateTime tradeAt;
 
     try {

--- a/src/main/java/com/example/backend/ocr/ReceiptParser.java
+++ b/src/main/java/com/example/backend/ocr/ReceiptParser.java
@@ -95,7 +95,7 @@ public class ReceiptParser {
       if (day < 1 || day > 31) day = 1;
       return LocalDateTime.of(year, month, day, hour, minute, second);
     } catch (Exception e) {
-      return LocalDateTime.now();
+      return null;
     }
   }
 

--- a/src/main/java/com/example/backend/service/InappropriateReasonService.java
+++ b/src/main/java/com/example/backend/service/InappropriateReasonService.java
@@ -31,18 +31,19 @@ public class InappropriateReasonService {
     List<StringBuilder> aiReasonParts = new ArrayList<>();
 
     LocalDateTime tradeAt = receipt.getTradeAt();
-    if (tradeAt == null) tradeAt = LocalDateTime.now();
 
-    if (isNightPayment(tradeAt)) {
-      reasons.add("NIGHT_PAYMENT");
-      aiReasonParts.add(new StringBuilder("심야시간(" + tradeAt.getHour() + "시) 결제 감지"));
-      log.info("=== 심야결제 감지: {}", tradeAt);
-    }
+    if (tradeAt != null) {
+      if (isNightPayment(tradeAt)) {
+        reasons.add("NIGHT_PAYMENT");
+        aiReasonParts.add(new StringBuilder("심야시간(" + tradeAt.getHour() + "시) 결제 감지"));
+        log.info("=== 심야결제 감지: {}", tradeAt);
+      }
 
-    if (isHolidayPayment(tradeAt.toLocalDate())) {
-      reasons.add("HOLIDAY_PAYMENT");
-      aiReasonParts.add(new StringBuilder("공휴일 결제 감지"));
-      log.info("=== 공휴일 결제 감지: {}", tradeAt.toLocalDate());
+      if (isHolidayPayment(tradeAt.toLocalDate())) {
+        reasons.add("HOLIDAY_PAYMENT");
+        aiReasonParts.add(new StringBuilder("공휴일 결제 감지"));
+        log.info("=== 공휴일 결제 감지: {}", tradeAt.toLocalDate());
+      }
     }
 
     if (isEntertainment(receipt.getStoreName(), category)) {

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -202,6 +202,11 @@ public class ReceiptService {
         tradeAt = null;
       }
 
+      if (tradeAt == null) {
+        log.warn("=== tradeAt null → confidence 하향 → NEED_MANUAL 유도");
+        confidence = Math.min(confidence, 0.4);
+      }
+
       List<String> derivedTags = tagService.deriveTags(Receipt.builder().tradeAt(tradeAt).build());
 
       JsonNode itemsNode = aiResult.path("items");

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -193,9 +193,13 @@ public class ReceiptService {
       LocalDateTime tradeAt;
       try {
         tradeAt =
-            LocalDateTime.parse(tradeAtStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+            (tradeAtStr != null && !tradeAtStr.isBlank())
+                ? LocalDateTime.parse(
+                    tradeAtStr, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+                : null;
       } catch (Exception e) {
-        tradeAt = LocalDateTime.now();
+        log.warn("=== tradeAt 파싱 실패, null 처리: {}", tradeAtStr);
+        tradeAt = null;
       }
 
       List<String> derivedTags = tagService.deriveTags(Receipt.builder().tradeAt(tradeAt).build());

--- a/src/main/resources/static/receipt-detail.html
+++ b/src/main/resources/static/receipt-detail.html
@@ -349,16 +349,25 @@
               `<tr><td>${escapeHtml(item.name)}</td><td>${item.quantity}</td><td>₩${(item.price || 0).toLocaleString()}</td></tr>`
       ).join('');
 
+
       const total = r.totalAmount || 0;
       const discount = r.discountAmount || 0;
-      const final = total - discount;
 
-      document.getElementById('summaryTotal').textContent = `₩${total.toLocaleString()}`;
+
+      const itemsTotal = (r.items || []).reduce((sum, item) =>
+              sum + (item.price * item.quantity), 0);
+
+      document.getElementById('summaryTotal').textContent =
+              `₩${(itemsTotal > 0 ? itemsTotal : total).toLocaleString()}`;
+
       if (discount > 0) {
         document.getElementById('summaryDiscountRow').style.display = 'flex';
-        document.getElementById('summaryDiscount').textContent = `-₩${discount.toLocaleString()}`;
+        document.getElementById('summaryDiscount').textContent =
+                `-₩${discount.toLocaleString()}`;
       }
-      document.getElementById('summaryFinal').textContent = `₩${final.toLocaleString()}`;
+
+      document.getElementById('summaryFinal').textContent =
+              `₩${total.toLocaleString()}`;
     }
   }
 

--- a/src/main/resources/static/receipt-detail.html
+++ b/src/main/resources/static/receipt-detail.html
@@ -279,6 +279,8 @@
     const aiResultEl = document.getElementById('aiResultArea');
     if (inappropriateReasons.length > 0) {
       aiResultEl.innerHTML = `<span class="ai-badge warning">${getAiLabel(inappropriateReasons)}</span>`;
+    } else if (r.status === 'NEED_MANUAL') {
+      aiResultEl.innerHTML = `<span class="ai-badge warning">수동 확인 필요</span>`;
     } else {
       aiResultEl.innerHTML = `<span class="ai-badge">AI 분석 결과 적절</span>`;
     }
@@ -423,6 +425,23 @@
       const storeNameEl = document.getElementById('editStoreName');
       const amountEl = document.getElementById('editAmount');
       const tradeAtEl = document.getElementById('editTradeAt');
+
+      if (storeNameEl && !storeNameEl.value.trim()) {
+        alert("가맹점명을 입력해주세요.");
+        storeNameEl.focus();
+        return;
+      }
+      if (amountEl && (!amountEl.value || Number(amountEl.value) <= 0)) {
+        alert("결제금액을 입력해주세요.");
+        amountEl.focus();
+        return;
+      }
+      if (tradeAtEl && !tradeAtEl.value) {
+        alert("결제일을 입력해주세요.");
+        tradeAtEl.focus();
+        return;
+      }
+
       if (storeNameEl || amountEl || tradeAtEl) {
         const body = {
           storeName: storeNameEl ? storeNameEl.value : null,


### PR DESCRIPTION
## ❓이슈
- close #87

## 📝 Description

### 1. 날짜 인식 실패 시 null 반환 및 NEED_MANUAL 유도
**문제:**
Gemini가 영수증 날짜를 인식하지 못할 경우
tradeAt에 현재 시각이 저장되는 버그가 있었습니다.
이로 인해 분석 시각이 23시 이후면 심야결제로 오탐되는
사이드 이펙트가 발생했습니다. (17번 크린토피아 케이스)

**변경:**
- ReceiptService.java: tradeAt 파싱 실패 시 null 반환
- ReceiptService.java: tradeAt null 시 confidence 0.4 하향
  → NEED_MANUAL로 자동 분류하여 수동 확인 유도
- ReceiptParser.java: 날짜 추출 실패 시 null 반환
- InappropriateReasonService.java: tradeAt null 시
  심야/공휴일 판정 블록 전체 스킵

**효과:**
날짜 인식 불가 영수증은 NEED_MANUAL로 분류되어
사용자가 직접 날짜를 입력 후 저장하도록 유도됩니다.
심야 오탐 버그도 함께 해결됩니다.

### 2. 웹페이지 결제금액 이중 차감 버그 수정
**문제:**
DB의 totalAmount는 이미 할인이 적용된 최종 결제금액인데
프론트엔드에서 summaryFinal을 totalAmount - discountAmount로
계산하여 할인금액이 이중으로 차감되는 버그가 있었습니다.

영향 케이스:
- 61번 이마트: 144,270원 → 99,900원으로 잘못 표시
- 80번 올리브영: 14,900원 → 8,800원으로 잘못 표시
- 90번 파리바게뜨: 21,400원 → 19,100원으로 잘못 표시

**변경:**
- 총 금액: items 합계(할인 전) 표시
- 할인 금액: discountAmount 표시
- 결제 금액: totalAmount 그대로 표시 (이중 차감 제거)

### 3. NEED_MANUAL 상태 UI 표시 개선
**문제:**
inappropriateReasons가 비어있으면 status와 무관하게
"AI 분석 결과 적절"로 표시되어 사용자가 수동 확인이
필요한 상황임을 인지하지 못하는 문제가 있었습니다.

**변경:**
- inappropriateReasons 있음 → 의심 거래 표시 (기존 유지)
- inappropriateReasons 없고 NEED_MANUAL → "수동 확인 필요" 표시
- 그 외 → "AI 분석 결과 적절" 표시

### 4. 영수증 저장 시 필수값 검증 추가
**문제:**
날짜 인식 실패로 tradeAt이 null인 상태에서
사용자가 날짜를 입력하지 않고 저장 버튼을 누르면
null인 채로 저장될 수 있는 문제가 있었습니다.

**변경:**
프론트/백엔드 이중 검증 구조로 방어
- receipt-detail.html: 저장 전 가맹점명/결제금액/결제일
  미입력 시 alert 표시 후 해당 필드 포커스
- ReceiptController.java: storeName/totalAmount/tradeAt
  누락 시 400 Bad Request 반환

## 🌀 PR Type
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 17번 크린토피아 재업로드 → tradeAt null + NEED_MANUAL 확인
- [x] 날짜 미입력 저장 시 alert 표시 확인
- [x] 80번 올리브영 ₩14,900 정상 표시 확인
- [x] 90번 파리바게뜨 ₩21,400 정상 표시 확인
- [x] NEED_MANUAL 영수증 "수동 확인 필요" 표시 확인
- [x] storeName 없이 PUT 요청 시 400 반환 확인