### PR TITLE
♻️ refactor: amountMismatch 수식 고도화 및 status 결정 로직 개선

### DIFF
--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -368,8 +368,7 @@ public class ReceiptService {
     Long currentUserId = getCurrentUserId();
     Receipt receipt = getReceiptSecurely(id, workspaceId);
 
-    if (receipt.getStatus() == ReceiptStatus.APPROVED
-        || receipt.getStatus() == ReceiptStatus.REJECTED) {
+    if (receipt.getStatus() != ReceiptStatus.WAITING) {
       throw new BusinessException(ErrorCode.AUDIT_ALREADY_DECIDED);
     }
 

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -202,11 +202,6 @@ public class ReceiptService {
         tradeAt = null;
       }
 
-      if (tradeAt == null) {
-        log.warn("=== tradeAt null → confidence 하향 → NEED_MANUAL 유도");
-        confidence = Math.min(confidence, 0.4);
-      }
-
       List<String> derivedTags = tagService.deriveTags(Receipt.builder().tradeAt(tradeAt).build());
 
       JsonNode itemsNode = aiResult.path("items");
@@ -229,22 +224,33 @@ public class ReceiptService {
         }
 
         if (itemsTotal > 0) {
-          int itemsTotalWithTax = itemsTotal + tax;
-          boolean amountMismatch =
-              Math.abs(itemsTotal - totalAmount) > totalAmount * 0.1
-                  && Math.abs(itemsTotalWithTax - totalAmount) > totalAmount * 0.1;
+          boolean hasDiscount = discountAmount > 0;
+          double toleranceRate = hasDiscount ? 0.03 : 0.01;
+          int tolerance = Math.max(1, (int) (totalAmount * toleranceRate));
+
+          int expectedTotal = itemsTotal - discountAmount;
+          boolean amountMismatch = Math.abs(expectedTotal - totalAmount) > tolerance;
 
           if (amountMismatch) {
             log.warn(
-                "=== items 합계({}) + tax({}) = {} / totalAmount({}) 10% 이상 차이 → NEED_MANUAL 유도",
-                itemsTotal, tax, itemsTotalWithTax, totalAmount);
+                "=== [금액검증] items합계({}) - discount({}) = {}"
+                    + " / totalAmount({}) / 허용오차({}, {}%)"
+                    + " → NEED_MANUAL 유도",
+                itemsTotal,
+                discountAmount,
+                expectedTotal,
+                totalAmount,
+                tolerance,
+                hasDiscount ? 3 : 1);
             confidence = Math.min(confidence, 0.4);
           }
         }
       }
 
+      boolean hasCriticalMissing = storeName.isBlank() || totalAmount <= 0 || tradeAt == null;
+
       ReceiptStatus nextStatus =
-          (confidence >= 0.7 && !storeName.isBlank())
+          (!hasCriticalMissing && confidence >= 0.7)
               ? ReceiptStatus.ANALYZING
               : ReceiptStatus.NEED_MANUAL;
 

--- a/src/main/resources/static/receipt-detail.html
+++ b/src/main/resources/static/receipt-detail.html
@@ -316,12 +316,12 @@
       document.getElementById('totalAmount').textContent = `₩${(r.totalAmount || 0).toLocaleString()}`;
       document.getElementById('tradeAt').textContent =
               r.tradeAt ? r.tradeAt.replace('T', ' ').substring(0, 16) : '-';
-      if (!isFinal && checkIsAdmin()) {
+      if (r.status === 'WAITING' && checkIsAdmin()) {
         document.getElementById('actionArea').innerHTML = `
-          <div class="action-btns">
-            <button class="btn btn-reject" onclick="openModal('rejectModal')">반려</button>
-            <button class="btn btn-approve" onclick="openModal('approveModal')">승인</button>
-          </div>`;
+      <div class="action-btns">
+        <button class="btn btn-reject" onclick="openModal('rejectModal')">반려</button>
+        <button class="btn btn-approve" onclick="openModal('approveModal')">승인</button>
+      </div>`;
       }
     }
 


### PR DESCRIPTION
## ❓이슈
- close #88

## 📝 Description

### 1. status 결정 로직 개선
**문제:**
기존 로직은 confidence와 storeName만으로 status를
결정하여 totalAmount=0이거나 tradeAt=null인 경우에도
ANALYZING으로 분류될 수 있는 구멍이 있었습니다.

**변경:**
- 기존: confidence >= 0.7 && storeName 있음
- 변경: storeName + totalAmount + tradeAt 3개 모두 존재
         AND confidence >= 0.7 → ANALYZING
         하나라도 없으면 → NEED_MANUAL

```java
boolean hasCriticalMissing =
    storeName.isBlank() || totalAmount <= 0 || tradeAt == null;

ReceiptStatus nextStatus =
    (!hasCriticalMissing && confidence >= 0.7)
        ? ReceiptStatus.ANALYZING
        : ReceiptStatus.NEED_MANUAL;
```

**효과:**
- totalAmount=0 → 명시적 NEED_MANUAL
- tradeAt=null → 명시적 NEED_MANUAL
  (기존의 confidence 하향 방식 → 명시적 체크로 대체)

### 2. amountMismatch 수식 고도화
**문제:**
기존 수식은 discountAmount를 포함하지 않아
할인이 있는 영수증에서 items 합계가 totalAmount와
항상 불일치하는 오탐이 발생할 수 있었습니다.
또한 10% 허용 오차는 금융 데이터 기준으로 너무 느슨했습니다.

**변경:**
- 기존 수식: itemsTotal vs totalAmount (10% 허용)
- 변경 수식: itemsTotal - discountAmount vs totalAmount
  - 할인 없음(discountAmount=0): 1% 허용
    (이유: tax 오인식 흡수)
  - 할인 있음(discountAmount>0): 3% 허용
    (이유: discountAmount 인식률 98% 기준,
           2% 오차 가능 + 안전마진 1%)

```java
boolean hasDiscount = discountAmount > 0;
double toleranceRate = hasDiscount ? 0.03 : 0.01;
int tolerance = Math.max(1, (int)(totalAmount * toleranceRate));

int expectedTotal = itemsTotal - discountAmount;
boolean amountMismatch =
    Math.abs(expectedTotal - totalAmount) > tolerance;
```

**효과:**
- 기존 10% 대비 3~10배 엄격한 기준 적용
- 할인 구조를 반영한 정밀 검증
- NEED_MANUAL 정밀화

### 3. tradeAt null confidence 하향 코드 제거
**변경:**
- status 결정 로직에서 hasCriticalMissing으로
  명시적 처리하므로 불필요한 confidence 하향 코드 제거
- 코드 가독성 및 예측 가능성 향상

### 4. WAITING 상태에서만 승인/반려 가능하도록 수정
**문제:**
기존 코드는 APPROVED, REJECTED 상태에서만 상태변경을
막고 있어 ANALYZING, NEED_MANUAL 상태에서도
승인/반려 API 호출이 가능한 버그가 있었습니다.

업로더가 아직 저장 확정하지 않은 영수증은
관리자 감사 대상이 아니므로 승인/반려가
불가능해야 합니다.

**변경:**
- ReceiptService.java: WAITING 상태가 아니면 예외 발생
- receipt-detail.html: WAITING 상태일 때만
  승인/반려 버튼 표시

```java
// 기존
if (receipt.getStatus() == ReceiptStatus.APPROVED
    || receipt.getStatus() == ReceiptStatus.REJECTED) {
  throw new BusinessException(ErrorCode.AUDIT_ALREADY_DECIDED);
}

// 변경
if (receipt.getStatus() != ReceiptStatus.WAITING) {
  throw new BusinessException(ErrorCode.AUDIT_ALREADY_DECIDED);
}
```

## 🌀 PR Type
- [x] 버그 수정
- [x] 코드 리팩토링

## ✅ Checklist
### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인

### status 결정 로직 검증
- [x] 17번 크린토피아 (tradeAt=null)
      → hasCriticalMissing=true → NEED_MANUAL ✅
- [x] 8번 메가MGC커피 (정상 영수증)
      → storeName/totalAmount/tradeAt 모두 존재
      → confidence=0.9 → ANALYZING ✅

### amountMismatch 수식 검증
- [x] 86번 파리바게뜨 (할인있음, discountAmount=2300)
      → itemsTotal(23700) - discount(2300) = 21400
      → totalAmount(21400) 일치 → ANALYZING ✅
- [x] 61번 이마트 김포한강점 (복잡한 할인구조)
      → discountAmount 오인식으로 불일치
      → NEED_MANUAL ✅ (의도된 동작)
- [x] 76번 올리브영 (원가/판매가 혼재)
      → items단가(14900) - discount(6100) = 8800
      → totalAmount(14900) 불일치
      → NEED_MANUAL ✅ (의도된 동작)

### 승인/반려 상태 검증
- [x] WAITING 영수증 → 승인/반려 버튼 보임 ✅
- [x] ANALYZING 영수증 → 승인/반려 버튼 안 보임 ✅
- [x] NEED_MANUAL 영수증 → 승인/반려 버튼 안 보임 ✅
- [x] Swagger에서 ANALYZING 영수증 PATCH → 400 반환 ✅
- [x] Swagger에서 NEED_MANUAL 영수증 PATCH → 400 반환 ✅