### PR TITLE
🐛 fix: 영수증 API 에러 응답 body 누락 및 필수 필드 검증 추가

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -13,6 +13,7 @@ import com.example.backend.dto.UploadReceiptResponse;
 import com.example.backend.entity.Receipt;
 import com.example.backend.global.common.ApiListResponse;
 import com.example.backend.global.common.ApiResponse;
+import com.example.backend.global.error.ErrorCode;
 import com.example.backend.repository.ReceiptRepository;
 import com.example.backend.service.ExcelExportService;
 import com.example.backend.service.ReceiptService;
@@ -183,10 +184,12 @@ public class ReceiptController {
   @GetMapping("/export")
   public ResponseEntity<byte[]> exportToExcel(
       @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
+
+    if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
+      throw ErrorCode.WS_ADMIN_REQUIRED.toException();
+    }
+
     try {
-      if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
-        return ResponseEntity.status(403).build();
-      }
       List<Receipt> receipts = receiptRepository.findAllByWorkspaceId(workspaceId);
       byte[] out = excelExportService.generateExcel(receipts, workspaceId);
 
@@ -225,18 +228,19 @@ public class ReceiptController {
   })
   @PostMapping("/export/selected")
   public ResponseEntity<byte[]> exportSelectedToExcel(@RequestBody ExportSelectedRequest request) {
+
+    Long workspaceId = request.getWorkspaceId();
+    List<Long> receiptIds = request.getReceiptIds();
+
+    if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
+      throw ErrorCode.WS_ADMIN_REQUIRED.toException();
+    }
+
+    if (receiptIds.isEmpty()) {
+      throw ErrorCode.INVALID_REQUEST.toException("선택된 영수증이 없습니다.");
+    }
+
     try {
-      Long workspaceId = request.getWorkspaceId();
-      List<Long> receiptIds = request.getReceiptIds();
-
-      if (!receiptService.isAdminOfWorkspace(receiptService.getCurrentUserId(), workspaceId)) {
-        return ResponseEntity.status(403).build();
-      }
-
-      if (receiptIds.isEmpty()) {
-        return ResponseEntity.badRequest().build();
-      }
-
       List<Receipt> receipts =
           receiptIds.stream()
               .map(id -> receiptRepository.findByIdAndWorkspaceId(id, workspaceId).orElse(null))
@@ -432,13 +436,13 @@ public class ReceiptController {
     String tradeAtValue = request.getTradeAt();
 
     if (storeName == null || storeName.isBlank()) {
-      return ResponseEntity.badRequest().build();
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("가맹점명을 입력해주세요.");
     }
     if (totalAmount == null || totalAmount <= 0) {
-      return ResponseEntity.badRequest().build();
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("결제금액을 입력해주세요.");
     }
     if (tradeAtValue == null || tradeAtValue.isBlank()) {
-      return ResponseEntity.badRequest().build();
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("결제일시를 입력해주세요.");
     }
 
     LocalDateTime tradeAt;
@@ -450,7 +454,8 @@ public class ReceiptController {
                   tradeAtValue, java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
               : LocalDateTime.now();
     } catch (Exception e) {
-      return ResponseEntity.badRequest().build();
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException(
+          "결제일시 형식이 올바르지 않습니다. (yyyy-MM-dd HH:mm:ss)");
     }
 
     return ResponseEntity.ok(

--- a/src/main/java/com/example/backend/global/error/ErrorCode.java
+++ b/src/main/java/com/example/backend/global/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
   AUDIT_ALREADY_DECIDED(HttpStatus.BAD_REQUEST, "이미 승인 또는 반려된 영수증은 수정할 수 없습니다."),
   REJECT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "영수증 반려 시 사유 입력은 필수입니다."),
+  RECEIPT_REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "필수 항목(가맹점명, 결제금액, 결제일시)을 입력해주세요."),
   RECEIPT_DUPLICATE(HttpStatus.CONFLICT, "이미 등록된 영수증입니다."),
   AI_PARSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AI 분석 중 오류가 발생했습니다."),
   OCR_CONNECTION_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "OCR 서버와의 통신에 실패했습니다."),

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -571,6 +571,17 @@ public class ReceiptService {
   @Transactional
   public Receipt confirmReceipt(Long id, Long workspaceId) {
     Receipt receipt = getReceiptSecurely(id, workspaceId);
+
+    if (receipt.getStoreName() == null || receipt.getStoreName().isBlank()) {
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("가맹점명을 입력해주세요.");
+    }
+    if (receipt.getTotalAmount() <= 0) {
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("결제금액을 입력해주세요.");
+    }
+    if (receipt.getTradeAt() == null) {
+      throw ErrorCode.RECEIPT_REQUIRED_FIELD_MISSING.toException("결제일시를 입력해주세요.");
+    }
+
     receipt.confirm();
     return receipt;
   }


### PR DESCRIPTION
## ❓이슈
- close #96

## :memo: Description

영수증 API 일부에서 에러 발생 시 응답 body가 없거나 백엔드 필수 필드 검증이 누락된 문제를 수정했습니다.

**문제 1. `PATCH /receipts/{id}/confirm` — 필수 필드 백엔드 검증 누락**
- 저장 버튼 클릭 시 프론트 단 alert만 존재하고 백엔드 검증 없음
- API 직접 호출 시 결제일·가맹점명·결제금액이 null인 상태로 WAITING 저장 가능
- `ReceiptService.confirmReceipt()`에 필수 필드 검증 로직 추가
- `ErrorCode.java`에 `RECEIPT_REQUIRED_FIELD_MISSING` 에러코드 추가

**문제 2. `PUT /receipts/{id}` — 400 응답 body 없음**
- 필수 필드 검증 실패 및 날짜 파싱 실패 시 `ResponseEntity.badRequest().build()`로 body 없이 반환
- 프론트에서 어떤 필드가 문제인지 알 수 없는 상태
- `RECEIPT_REQUIRED_FIELD_MISSING` throw로 교체하여 에러코드 + 메시지 포함 응답으로 수정

**문제 3. `GET /receipts/export` — 403 응답 body 없음**
- 관리자 아닌 사용자 호출 시 `ResponseEntity.status(403).build()`로 body 없이 반환
- 권한 체크가 `try-catch` 안에 있어 `throw`로 바꿔도 `catch`에 잡혀 500으로 반환되는 구조적 문제
- 권한 체크를 `try-catch` 밖으로 분리 후 `WS_ADMIN_REQUIRED` throw로 교체

**문제 4. `POST /receipts/export/selected` — 403/400 응답 body 없음**
- 문제 3과 동일한 구조적 문제
- 선택된 영수증 없을 때도 body 없는 400 반환
- `WS_ADMIN_REQUIRED` + `INVALID_REQUEST` throw로 교체

**프론트 에러 응답 포맷**
```json
{
  "success": false,
  "error": {
    "code": "RECEIPT_REQUIRED_FIELD_MISSING",
    "message": "결제일시를 입력해주세요."
  }
}
```

| 에러코드 | HTTP | 발생 위치 | 내용 |
|---------|------|----------|------|
| `RECEIPT_REQUIRED_FIELD_MISSING` | 400 | `PATCH /confirm`, `PUT /{id}` | 결제일·가맹점명·결제금액 누락 시 |
| `WS_ADMIN_REQUIRED` | 403 | `GET /export`, `POST /export/selected` | 관리자 아닌 사용자 접근 시 |
| `INVALID_REQUEST` | 400 | `POST /export/selected` | 선택된 영수증 없을 때 |

PATCH /confirm (결제일 누락)
<img width="444" height="327" alt="image" src="https://github.com/user-attachments/assets/dc0bf026-d8c2-4217-b294-4338092511b8" />

PUT /{id} (가맹점명 누락)
<img width="423" height="329" alt="image" src="https://github.com/user-attachments/assets/b656da45-e6dd-4c6d-a3a3-067b941746f0" />

GET /export (Member로 접근 시)
<img width="429" height="328" alt="image" src="https://github.com/user-attachments/assets/f1f27d25-ff65-4f80-b357-210b520d67b0" />

POST /export/selected (Member로 접근 시)
<img width="413" height="330" alt="image" src="https://github.com/user-attachments/assets/5f115b3e-6698-48f2-8adb-ef0ca36f860f" />

POST /export/selected (선택된 영수증 없을 시)
<img width="417" height="333" alt="image" src="https://github.com/user-attachments/assets/4eba86dd-d9c2-454d-a513-e9fbd2c1a9cc" />



## :cyclone: PR Type
어떤 변경 사항이 있나요?
- [x] 버그 수정

## :white_check_mark: Checklist
### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] `PATCH /confirm` 결제일 누락 시 `RECEIPT_REQUIRED_FIELD_MISSING` 400 응답 확인
- [x] `PUT /{id}` 가맹점명 누락 시 `RECEIPT_REQUIRED_FIELD_MISSING` 400 응답 확인
- [x] `GET /export` MEMBER 계정으로 접근 시 `WS_ADMIN_REQUIRED` 403 응답 확인
- [x] `POST /export/selected` MEMBER 계정으로 접근 시 `WS_ADMIN_REQUIRED` 403 응답 확인
- [x] `POST /export/selected` 선택된 영수증 없을 때 `INVALID_REQUEST` 400 응답 확인