### PR TITLE
✨ feat: 영수증 목록 조회 필터 페이지네이션

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -118,9 +119,32 @@ public class ReceiptController {
   })
   @GetMapping
   public ResponseEntity<ApiListResponse<ReceiptSummaryDto>> getAllReceipts(
-      @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
-    List<ReceiptSummaryDto> list = receiptService.getWorkspaceReceipts(workspaceId);
-    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 1, 0));
+      @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId,
+      @Parameter(description = "가맹점명 검색", example = "스타벅스") @RequestParam(required = false)
+          String storeName,
+      @Parameter(description = "게시자 ID", example = "1") @RequestParam(required = false) Long userId,
+      @Parameter(description = "상태 필터", example = "WAITING") @RequestParam(required = false)
+          ReceiptStatus status,
+      @Parameter(description = "정렬 (LATEST/OLDEST)", example = "LATEST")
+          @RequestParam(required = false, defaultValue = "LATEST")
+          String sort,
+      @Parameter(description = "페이지 번호", example = "0")
+          @RequestParam(required = false, defaultValue = "0")
+          int page,
+      @Parameter(description = "페이지 크기", example = "10")
+          @RequestParam(required = false, defaultValue = "10")
+          int size) {
+
+    Page<ReceiptSummaryDto> result =
+        receiptService.getWorkspaceReceipts(
+            workspaceId, storeName, userId, status, sort, page, size);
+
+    return ResponseEntity.ok(
+        ApiListResponse.ok(
+            result.getContent(),
+            result.getTotalElements(),
+            result.getTotalPages(),
+            result.getNumber()));
   }
 
   @Operation(summary = "영수증 단건 조회", description = "영수증 ID로 단건 상세 조회합니다.")

--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -120,7 +120,7 @@ public class ReceiptController {
   public ResponseEntity<ApiListResponse<ReceiptSummaryDto>> getAllReceipts(
       @Parameter(description = "워크스페이스 ID", example = "1") @RequestParam Long workspaceId) {
     List<ReceiptSummaryDto> list = receiptService.getWorkspaceReceipts(workspaceId);
-    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 0));
+    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 1, 0));
   }
 
   @Operation(summary = "영수증 단건 조회", description = "영수증 ID로 단건 상세 조회합니다.")
@@ -521,7 +521,7 @@ public class ReceiptController {
   @GetMapping("/{id}/history")
   public ResponseEntity<ApiListResponse<AuditLog>> getHistory(@PathVariable Long id) {
     List<AuditLog> logs = auditLogService.findAllByReceiptId(id);
-    return ResponseEntity.ok(ApiListResponse.ok(logs, logs.size(), 0));
+    return ResponseEntity.ok(ApiListResponse.ok(logs, logs.size(), 1, 0));
   }
 
   @Operation(summary = "워크스페이스 통계 조회", description = "워크스페이스의 영수증 통계를 조회합니다.")

--- a/src/main/java/com/example/backend/controller/WorkspaceController.java
+++ b/src/main/java/com/example/backend/controller/WorkspaceController.java
@@ -171,7 +171,7 @@ public class WorkspaceController {
       @Parameter(hidden = true) Principal principal) {
     List<WorkspaceMemberResponseDto> list =
         workspaceService.getWorkspaceMembers(workspaceId, status, principal.getName());
-    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 0));
+    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 1, 0));
   }
 
   @Operation(summary = "워크스페이스 설정 수정")
@@ -338,7 +338,7 @@ public class WorkspaceController {
   public ResponseEntity<ApiListResponse<WorkspaceResponseDto>> getInvitations(
       @Parameter(hidden = true) Principal principal) {
     List<WorkspaceResponseDto> list = workspaceService.getPendingInvitations(principal.getName());
-    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 0));
+    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 1, 0));
   }
 
   @Operation(summary = "초대 수락")
@@ -445,6 +445,6 @@ public class WorkspaceController {
   public ResponseEntity<ApiListResponse<WorkspaceResponseDto>> getMyWorkspaces(
       @Parameter(hidden = true) Principal principal) {
     List<WorkspaceResponseDto> list = workspaceService.getMyWorkspaces(principal.getName());
-    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 0));
+    return ResponseEntity.ok(ApiListResponse.ok(list, list.size(), 1, 0));
   }
 }

--- a/src/main/java/com/example/backend/global/common/ApiListResponse.java
+++ b/src/main/java/com/example/backend/global/common/ApiListResponse.java
@@ -10,15 +10,17 @@ import org.slf4j.MDC;
 public record ApiListResponse<T>(
     @Schema(description = "성공 여부", example = "true") boolean success,
     @Schema(description = "전체 개수", example = "5") long totalCount,
-    @Schema(description = "다음 페이지 커서 (없으면 0)", example = "0") int nextCursor,
+    @Schema(description = "전체 페이지 수", example = "5") int totalPages,
+    @Schema(description = "현재 페이지 번호", example = "0") int currentPage,
     @Schema(description = "데이터 목록") List<T> data,
     @Schema(description = "메타 정보") Meta meta) {
 
-  public static <T> ApiListResponse<T> ok(List<T> data, long totalCount, int nextCursor) {
+  public static <T> ApiListResponse<T> ok(
+      List<T> data, long totalCount, int totalPages, int currentPage) {
     String traceId = MDC.get(TraceIdFilter.MDC_KEY);
     if (traceId == null || traceId.isBlank()) {
       traceId = "no-trace-" + OffsetDateTime.now().toEpochSecond();
     }
-    return new ApiListResponse<>(true, totalCount, nextCursor, data, Meta.of(traceId));
+    return new ApiListResponse<>(true, totalCount, totalPages, currentPage, data, Meta.of(traceId));
   }
 }

--- a/src/main/java/com/example/backend/repository/ReceiptRepository.java
+++ b/src/main/java/com/example/backend/repository/ReceiptRepository.java
@@ -1,9 +1,12 @@
 package com.example.backend.repository;
 
+import com.example.backend.domain.receipt.ReceiptStatus;
 import com.example.backend.entity.Receipt;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +26,19 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
   Optional<Receipt> findByIdAndUserId(Long id, Long userId);
 
   List<Receipt> findAllByWorkspaceId(Long workspaceId);
+
+  @Query(
+      "SELECT r FROM Receipt r "
+          + "WHERE r.workspaceId = :workspaceId "
+          + "AND (:storeName IS NULL OR LOWER(r.storeName) LIKE LOWER(CONCAT('%', :storeName, '%'))) "
+          + "AND (:userId IS NULL OR r.userId = :userId) "
+          + "AND (:status IS NULL OR r.status = :status)")
+  Page<Receipt> findByWorkspaceIdWithFilters(
+      @Param("workspaceId") Long workspaceId,
+      @Param("storeName") String storeName,
+      @Param("userId") Long userId,
+      @Param("status") ReceiptStatus status,
+      Pageable pageable);
 
   Optional<Receipt> findByIdAndWorkspaceId(Long id, Long workspaceId);
 

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -38,6 +38,10 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -447,35 +451,53 @@ public class ReceiptService {
   }
 
   @Transactional(readOnly = true)
-  public List<ReceiptSummaryDto> getWorkspaceReceipts(Long workspaceId) {
+  public Page<ReceiptSummaryDto> getWorkspaceReceipts(
+      Long workspaceId,
+      String storeName,
+      Long userId,
+      ReceiptStatus status,
+      String sort,
+      int page,
+      int size) {
 
-    List<Receipt> receipts = receiptRepository.findAllByWorkspaceId(workspaceId);
+    Sort sortOrder =
+        "OLDEST".equalsIgnoreCase(sort)
+            ? Sort.by(Sort.Direction.ASC, "createdAt")
+            : Sort.by(Sort.Direction.DESC, "createdAt");
 
-    return receipts.stream()
-        .map(
-            r -> {
-              String ownerName =
-                  userRepository.findById(r.getUserId()).map(u -> u.getName()).orElse("알 수 없음");
+    Pageable pageable = PageRequest.of(page, size, sortOrder);
 
-              return new ReceiptSummaryDto(
-                  r.getId(),
-                  r.getStoreName(),
-                  r.getTotalAmount(),
-                  r.getTradeAt(),
-                  r.getStatus(),
-                  ownerName,
-                  r.getTags(),
-                  r.getRejectionReason(),
-                  r.getUserId(),
-                  r.getTax(),
-                  r.getConfidence(),
-                  r.getCreatedAt(),
-                  r.getInappropriateReasons(),
-                  r.getDiscountAmount(),
-                  r.getAiReason(),
-                  r.getCategory());
-            })
-        .collect(Collectors.toList());
+    Page<Receipt> receipts =
+        receiptRepository.findByWorkspaceIdWithFilters(
+            workspaceId,
+            (storeName == null || storeName.isBlank()) ? null : storeName,
+            userId,
+            status,
+            pageable);
+
+    return receipts.map(
+        r -> {
+          String ownerName =
+              userRepository.findById(r.getUserId()).map(u -> u.getName()).orElse("알 수 없음");
+
+          return new ReceiptSummaryDto(
+              r.getId(),
+              r.getStoreName(),
+              r.getTotalAmount(),
+              r.getTradeAt(),
+              r.getStatus(),
+              ownerName,
+              r.getTags(),
+              r.getRejectionReason(),
+              r.getUserId(),
+              r.getTax(),
+              r.getConfidence(),
+              r.getCreatedAt(),
+              r.getInappropriateReasons(),
+              r.getDiscountAmount(),
+              r.getAiReason(),
+              r.getCategory());
+        });
   }
 
   private SavedReceiptFile saveReceiptFile(MultipartFile file, Long userId, Long workspaceId) {

--- a/src/main/resources/static/upload.html
+++ b/src/main/resources/static/upload.html
@@ -150,7 +150,9 @@
 
 <script>
     let receiptData = [];
-    let allReceipts = [];
+    let currentPage = 0;
+    let totalPages = 0;
+    const PAGE_SIZE = 10;
     const el = id => document.getElementById(id);
     const escapeHtml = s => String(s ?? '').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
     const token = localStorage.getItem('accessToken');
@@ -231,31 +233,40 @@
         } catch (e) { console.error(e); }
     }
 
-    async function fetchReceipts() {
+    async function fetchReceipts(page = 0) {
         try {
-            const res = await fetch(`/api/v1/receipts?workspaceId=${workspaceId}`, { headers: { 'Authorization': `Bearer ${token}` } });
+            const storeName = el('searchInput').value.trim();
+            const userFilter = el('filterUser').value;
+            const statusFilter = el('filterStatus').value;
+            const sort = el('filterSort').value === 'oldest' ? 'OLDEST' : 'LATEST';
+
+            const params = new URLSearchParams({
+                workspaceId,
+                page,
+                size: PAGE_SIZE,
+                sort
+            });
+            if (storeName) params.append('storeName', storeName);
+            if (userFilter) params.append('userId', userFilter);
+            if (statusFilter) params.append('status', statusFilter);
+
+            const res = await fetch(`/api/v1/receipts?${params}`, {
+                headers: { 'Authorization': `Bearer ${token}` }
+            });
             const json = await res.json();
-            allReceipts = json.data || [];
-            const users = [...new Set(allReceipts.map(r => r.userName).filter(Boolean))];
-            el('filterUser').innerHTML = `<option value="">게시자 ▾</option>` + users.map(u => `<option value="${escapeHtml(u)}">${escapeHtml(u)}</option>`).join('');
-            filterReceipts();
+
+            receiptData = json.data || [];
+            currentPage = json.currentPage ?? 0;
+            totalPages = json.totalPages ?? 1;
+
+            renderReceipts();
+            renderPagination();
         } catch (e) { console.error(e); }
     }
 
     function filterReceipts() {
-        const search = el('searchInput').value.toLowerCase();
-        const userFilter = el('filterUser').value;
-        const statusFilter = el('filterStatus').value;
-        const sort = el('filterSort').value;
-        let filtered = allReceipts.filter(r => {
-            const matchSearch = !search || (r.storeName || '').toLowerCase().includes(search);
-            const matchUser = !userFilter || r.userName === userFilter;
-            const matchStatus = !statusFilter || r.status === statusFilter;
-            return matchSearch && matchUser && matchStatus;
-        });
-        filtered.sort((a, b) => sort === 'oldest' ? new Date(a.createdAt) - new Date(b.createdAt) : new Date(b.createdAt) - new Date(a.createdAt));
-        receiptData = filtered;
-        renderReceipts();
+        currentPage = 0;
+        fetchReceipts(0);
     }
 
     function renderReceipts() {
@@ -377,6 +388,64 @@
             window.URL.revokeObjectURL(url);
         } catch (e) { alert("다운로드 오류"); }
     }
+    async function loadMembers() {
+        try {
+            const res = await fetch(`/api/v1/workspaces/${workspaceId}/members`, {
+                headers: { 'Authorization': `Bearer ${token}` }
+            });
+            const json = await res.json();
+            const members = json.data || [];
+            el('filterUser').innerHTML =
+                `<option value="">게시자 ▾</option>` +
+                members.map(m =>
+                    `<option value="${m.userId}">${escapeHtml(m.name)}</option>`
+                ).join('');
+        } catch (e) { console.error(e); }
+    }
+    function renderPagination() {
+        let paginationEl = el('pagination');
+        if (!paginationEl) {
+            paginationEl = document.createElement('div');
+            paginationEl.id = 'pagination';
+            paginationEl.style.cssText =
+                'display:flex; justify-content:center; align-items:center; gap:8px; margin-top:20px;';
+            el('receiptList').closest('table').after(paginationEl);
+        }
+
+        if (totalPages <= 1) {
+            paginationEl.innerHTML = '';
+            return;
+        }
+
+        let html = '';
+        html += `<button onclick="fetchReceipts(${currentPage - 1})"
+        ${currentPage === 0 ? 'disabled' : ''}
+        style="padding:6px 12px; border-radius:8px; border:1px solid #e2e8f0;
+               background:#fff; cursor:pointer; font-weight:600;
+               ${currentPage === 0 ? 'opacity:0.4;cursor:not-allowed;' : ''}">
+        ← 이전
+    </button>`;
+
+        for (let i = 0; i < totalPages; i++) {
+            html += `<button onclick="fetchReceipts(${i})"
+            style="padding:6px 12px; border-radius:8px; border:1px solid #e2e8f0;
+                   background:${i === currentPage ? '#1e293b' : '#fff'};
+                   color:${i === currentPage ? '#fff' : '#475569'};
+                   cursor:pointer; font-weight:600;">
+            ${i + 1}
+        </button>`;
+        }
+
+        html += `<button onclick="fetchReceipts(${currentPage + 1})"
+        ${currentPage === totalPages - 1 ? 'disabled' : ''}
+        style="padding:6px 12px; border-radius:8px; border:1px solid #e2e8f0;
+               background:#fff; cursor:pointer; font-weight:600;
+               ${currentPage === totalPages - 1 ? 'opacity:0.4;cursor:not-allowed;' : ''}">
+        다음 →
+    </button>`;
+
+        paginationEl.innerHTML = html;
+    }
 
     el('dropZone').addEventListener('click', () => el('fileInput').click());
     el('fileInput').addEventListener('change', e => {
@@ -384,7 +453,7 @@
         el('thumbs').style.display = 'grid';
     });
     el('uploadBtn').onclick = uploadReceipts;
-    window.onload = () => { initLayout(); fetchStats(); fetchReceipts(); };
+    window.onload = () => { initLayout(); fetchStats(); loadMembers(); fetchReceipts(0); };
 </script>
 </body>
 </html>


### PR DESCRIPTION
## ❓이슈
- close #99

## :memo: Description

영수증 목록 조회 API에 검색, 필터, 정렬, 오프셋 기반 페이지네이션 기능을 추가했습니다.

**변경 1. `ApiListResponse.java` 응답 포맷 변경**
- `nextCursor` 제거
- `totalPages`, `currentPage` 추가

**변경 2. `ReceiptRepository.java` 필터 쿼리 추가**
- 가맹점명 부분 검색 (LOWER + LIKE)
- userId 필터
- status 필터
- Pageable로 정렬/페이지네이션 처리

**변경 3. `ReceiptService.getWorkspaceReceipts()` 파라미터 추가**
- storeName, userId, status, sort, page, size 파라미터 추가
- sort 값에 따라 Pageable Sort 방향 결정 (LATEST: DESC / OLDEST: ASC)

**변경 4. `ReceiptController.getAllReceipts()` 쿼리 파라미터 추가**
- storeName, userId, status, sort, page, size 쿼리 파라미터 추가
- 응답 포맷 변경 (totalElements, totalPages, currentPage 반환)

**변경 5. `upload.html` 연동**
- JS 단 필터링 제거 → 백엔드 API 필터 연동
- 페이지네이션 UI 추가 (이전/다음/페이지 번호 버튼)
- 게시자 필터를 멤버 목록 API로 동적 로드

<img width="523" height="929" alt="image" src="https://github.com/user-attachments/assets/9cd0c6f0-d144-4313-ae43-744d66785486" />

## :cyclone: PR Type

- [x] 새로운 기능 추가

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 기본 조회 (파라미터 없이) — totalCount, totalPages, currentPage 응답 확인
- [x] 가맹점명 검색 — 부분 일치 검색 확인
- [x] 상태 필터 — WAITING / APPROVED / REJECTED 필터 확인
- [x] 게시자 필터 — userId 기준 필터 확인
- [x] 정렬 — LATEST / OLDEST 정렬 확인
- [x] 페이지네이션 — page, size 파라미터 확인
- [x] 복합 조건 — 검색 + 필터 + 정렬 + 페이지 동시 적용 확인