### PR TITLE
✨ 워크스페이스 가입 순 정렬을 위한 WorkspaceMember 타임스탬프 추가

### DIFF
--- a/src/main/java/com/example/backend/entity/WorkspaceMember.java
+++ b/src/main/java/com/example/backend/entity/WorkspaceMember.java
@@ -1,13 +1,18 @@
 package com.example.backend.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class WorkspaceMember {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,6 +26,12 @@ public class WorkspaceMember {
 
   @Enumerated(EnumType.STRING)
   private MembershipStatus status;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
 
   public void updateStatus(MembershipStatus status) {
     this.status = status;

--- a/src/main/java/com/example/backend/repository/WorkspaceRepository.java
+++ b/src/main/java/com/example/backend/repository/WorkspaceRepository.java
@@ -1,11 +1,20 @@
 package com.example.backend.repository;
 
 import com.example.backend.entity.Workspace;
+import com.example.backend.entity.WorkspaceMember;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
   List<Workspace> findByNameContaining(String name);
+
+  @Query(
+      "SELECT wm FROM WorkspaceMember wm "
+          + "WHERE wm.userId = :userId AND wm.status = 'ACCEPTED' "
+          + "ORDER BY wm.updatedAt ASC")
+  List<WorkspaceMember> findAcceptedMembersByUserIdOrderByUpdatedAt(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/backend/service/WorkspaceService.java
+++ b/src/main/java/com/example/backend/service/WorkspaceService.java
@@ -33,17 +33,14 @@ public class WorkspaceService {
   @Transactional(readOnly = true)
   public String getWorkspaceAdminName(Long workspaceId) {
     workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
-
     WorkspaceMember adminMember =
         workspaceMemberRepository
             .findByWorkspaceIdAndRole(workspaceId, WorkspaceRole.ADMIN)
             .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
-
     User user =
         userRepository
             .findById(adminMember.getUserId())
             .orElseThrow(ErrorCode.USER_NOT_FOUND::toException);
-
     return user.getName();
   }
 
@@ -52,7 +49,6 @@ public class WorkspaceService {
     User user = findUserByPrincipal(principal);
     Workspace workspace =
         workspaceRepository.save(Workspace.builder().name(name).color(color).build());
-
     workspaceMemberRepository.save(
         WorkspaceMember.builder()
             .workspaceId(workspace.getId())
@@ -60,7 +56,6 @@ public class WorkspaceService {
             .role(WorkspaceRole.ADMIN)
             .status(MembershipStatus.ACCEPTED)
             .build());
-
     auditLogService.record(
         AuditAction.WORKSPACE_CREATE,
         "USER",
@@ -68,22 +63,18 @@ public class WorkspaceService {
         workspace.getId(),
         null,
         Map.of("workspaceName", name));
-
     return workspace.getId();
   }
 
   @Transactional(readOnly = true)
   public WorkspaceResponseDto getWorkspaceDetail(Long workspaceId, String principal) {
     User user = findUserByPrincipal(principal);
-
     Workspace ws =
         workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
-
     WorkspaceMember member =
         workspaceMemberRepository
             .findByWorkspaceIdAndUserId(workspaceId, user.getId())
             .orElseThrow(ErrorCode.WS_MEMBER_NOT_FOUND::toException);
-
     return WorkspaceResponseDto.builder()
         .workspaceId(ws.getId())
         .workspaceName(ws.getName())
@@ -97,16 +88,12 @@ public class WorkspaceService {
   public List<WorkspaceMemberResponseDto> getWorkspaceMembers(
       Long workspaceId, MembershipStatus status, String principal) {
     User requester = findUserByPrincipal(principal);
-
     workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
-
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, requester.getId())
         .orElseThrow(ErrorCode.WS_MEMBER_NOT_FOUND::toException);
-
     List<WorkspaceMember> members =
         workspaceMemberRepository.findAllByWorkspaceIdAndStatus(workspaceId, status);
-
     return members.stream()
         .map(
             m -> {
@@ -128,9 +115,7 @@ public class WorkspaceService {
   @Transactional
   public void updateWorkspaceSettings(
       Long workspaceId, String name, WorkspaceColor color, String principal) {
-    workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
     validateAdmin(workspaceId, principal);
-
     Workspace ws =
         workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
     if (name != null) ws.updateName(name);
@@ -139,24 +124,19 @@ public class WorkspaceService {
 
   @Transactional
   public void removeMember(Long workspaceId, Long targetUserId, String adminPrincipal) {
-    workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
     validateAdmin(workspaceId, adminPrincipal);
-
     WorkspaceMember member =
         workspaceMemberRepository
             .findByWorkspaceIdAndUserId(workspaceId, targetUserId)
             .orElseThrow(ErrorCode.WS_MEMBER_NOT_FOUND::toException);
-    if (member.getRole() == WorkspaceRole.ADMIN) {
+    if (member.getRole() == WorkspaceRole.ADMIN)
       throw ErrorCode.WS_CANNOT_REMOVE_ADMIN.toException();
-    }
     workspaceMemberRepository.delete(member);
   }
 
   @Transactional
   public void deleteWorkspace(Long workspaceId, String principal) {
-    workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
     validateAdmin(workspaceId, principal);
-
     workspaceMemberRepository.deleteAllByWorkspaceId(workspaceId);
     workspaceRepository.deleteById(workspaceId);
   }
@@ -166,7 +146,6 @@ public class WorkspaceService {
     User user = findUserByPrincipal(principal);
     List<WorkspaceMember> members =
         workspaceMemberRepository.findAllByUserIdAndStatus(user.getId(), MembershipStatus.PENDING);
-
     return members.stream()
         .map(
             m -> {
@@ -187,36 +166,29 @@ public class WorkspaceService {
 
   @Transactional
   public void inviteByEmail(Long workspaceId, String email, String adminPrincipal) {
-    workspaceRepository.findById(workspaceId).orElseThrow(ErrorCode.WS_NOT_FOUND::toException);
     validateAdmin(workspaceId, adminPrincipal);
-
     User invitee =
         userRepository
             .findByEmail(email)
             .orElseThrow(ErrorCode.WS_INVITE_EMAIL_INVALID::toException);
-
     workspaceMemberRepository
         .findByWorkspaceIdAndUserId(workspaceId, invitee.getId())
         .ifPresentOrElse(
             member -> {
-              if (member.getStatus() == MembershipStatus.ACCEPTED) {
+              if (member.getStatus() == MembershipStatus.ACCEPTED)
                 throw ErrorCode.WS_ALREADY_JOINED.toException();
-              }
-              if (member.getStatus() == MembershipStatus.PENDING) {
+              if (member.getStatus() == MembershipStatus.PENDING)
                 throw ErrorCode.WS_ALREADY_INVITED.toException();
-              }
               member.updateStatus(MembershipStatus.PENDING);
             },
-            () -> {
-              workspaceMemberRepository.save(
-                  WorkspaceMember.builder()
-                      .workspaceId(workspaceId)
-                      .userId(invitee.getId())
-                      .role(WorkspaceRole.MEMBER)
-                      .status(MembershipStatus.PENDING)
-                      .build());
-            });
-
+            () ->
+                workspaceMemberRepository.save(
+                    WorkspaceMember.builder()
+                        .workspaceId(workspaceId)
+                        .userId(invitee.getId())
+                        .role(WorkspaceRole.MEMBER)
+                        .status(MembershipStatus.PENDING)
+                        .build()));
     auditLogService.record(
         AuditAction.MEMBER_JOIN_REQUEST,
         "USER",
@@ -252,8 +224,10 @@ public class WorkspaceService {
   @Transactional(readOnly = true)
   public List<WorkspaceResponseDto> getMyWorkspaces(String principal) {
     User user = findUserByPrincipal(principal);
+
+    // 리포지토리의 반환 타입(List<WorkspaceMember>)에 맞춰 수정
     List<WorkspaceMember> members =
-        workspaceMemberRepository.findAllByUserIdAndStatus(user.getId(), MembershipStatus.ACCEPTED);
+        workspaceRepository.findAcceptedMembersByUserIdOrderByUpdatedAt(user.getId());
 
     return members.stream()
         .map(

--- a/src/main/resources/static/workspace-list.html
+++ b/src/main/resources/static/workspace-list.html
@@ -119,7 +119,7 @@
                     </div>
                     <div style="font-size:0.85rem; color:#94a3b8; margin-top:12px;">클릭하여 입장</div>
                 `;
-                grid.insertBefore(card, grid.firstChild);
+                grid.appendChild(card);
             });
         } catch (e) { console.error(e); }
     }


### PR DESCRIPTION
## ❓이슈

- close #101 

## :memo: Description

기존엔 워크스페이스 정렬 로직이 없었음
WorkspaceMember Entity에 created_at과 updated_at 타임스탬프를 추가
워크스페이스는 updated_at 컬럼을 기준으로 오름차순으로 정렬

다른 워크스페이스에서 온 초대를 받은 경우 멤버의 상태가 PENDING에서 ACCEPTED로 상태 전이가 되면서 updated_at 칼럼의 가장 나중의 시간으로 업데이트 됨. 결과적으로 워크스페이스 목록의 최하단으로 오게 된다.

자기가 직접 워크스페이스를 생성한 경우에는 created_at과 updated_at은 생성 직후 같은 시간으로 타임스탬프가 찍히기 때문에 결과적으론 db 내에서 가장 최신 시간이기에 워크스페이스의 목록의 최하단으로 오게 된다.

<br>
<br>
<img width="1284" height="412" alt="image" src="https://github.com/user-attachments/assets/5adf1b2b-127c-43d8-b5a0-65e3b83bc354" />
(workspace_member 테이블 예시)


## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
- [x] Swagger 확인
