### PR TITLE
✨ feat: 영수증 단건 조회 응답에 게시자 프로필 사진 필드 추가

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -188,7 +188,8 @@ public class ReceiptController {
                                               "inappropriateReasons": [],
                                               "discountAmount": 0,
                                               "aiReason": "정상 영수증으로 판단됨",
-                                              "category": "FOOD"
+                                              "category": "FOOD",
+                                              "userPicture": "/api/v1/files/178"
                                             },
                                             "meta": {
                                               "timestamp": "2026-03-24T19:36:08.117",

--- a/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
@@ -66,4 +66,7 @@ public class ReceiptDetailDto {
 
   @Schema(description = "업종 분류", example = "FOOD")
   private String category;
+
+  @Schema(description = "게시자 프로필 사진", nullable = true)
+  private String userPicture;
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -613,6 +613,8 @@ public class ReceiptService {
     Receipt receipt = getReceiptSecurely(id, workspaceId);
     String ownerName =
         userRepository.findById(receipt.getUserId()).map(u -> u.getName()).orElse("알 수 없음");
+    String ownerPicture =
+        userRepository.findById(receipt.getUserId()).map(u -> u.getPicture()).orElse(null);
     List<ReceiptItem> items = receiptItemRepository.findAllByReceiptId(id);
 
     return new ReceiptDetailDto(
@@ -633,7 +635,8 @@ public class ReceiptService {
         receipt.getInappropriateReasons(),
         receipt.getDiscountAmount(),
         receipt.getAiReason(),
-        receipt.getCategory());
+        receipt.getCategory(),
+        ownerPicture);
   }
 
   public ReceiptActionResponseDto toReceiptActionResponse(Receipt receipt) {


### PR DESCRIPTION
## ❓이슈
- close #107

## :memo: Description

영수증 단건 조회 API(`GET /api/v1/receipts/{id}`) 응답에 게시자 프로필 사진 필드를 추가했습니다.

기존에는 `userName`만 응답에 포함되어 있어 프론트에서 게시자 프로필 사진을 표시하려면
멤버 목록 조회 API를 추가로 호출해야 했습니다.

`userPicture` 필드를 추가하여 단건 조회 API 하나로 해결할 수 있도록 수정했습니다.

**변경된 응답 필드**
- `userPicture`: 게시자 프로필 사진 URL (없으면 null)

## :cyclone: PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] GET /api/v1/receipts/{id} 응답에 userPicture 필드 확인