### PR TITLE
🐛 fix: 카카오 소셜 로그인 시 프로필 이미지 null 반환 오류 수정

### DIFF
--- a/src/main/java/com/example/backend/service/AuthService.java
+++ b/src/main/java/com/example/backend/service/AuthService.java
@@ -130,8 +130,14 @@ public class AuthService {
       Map<String, Object> userInfo = getKakaoUserInfo(kakaoAccessToken);
       Map<String, Object> kakaoAccount = (Map<String, Object>) userInfo.get("kakao_account");
       Map<String, Object> properties = (Map<String, Object>) userInfo.get("properties");
+      Map<String, Object> profile =
+          kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
       email = kakaoAccount != null ? (String) kakaoAccount.get("email") : null;
       name = properties != null ? (String) properties.get("nickname") : "카카오유저";
+      image = profile != null ? (String) profile.get("profile_image_url") : null;
+      if (image == null && properties != null) {
+        image = (String) properties.get("profile_image");
+      }
       if (email == null) email = "kakao_" + userInfo.get("id") + "@noemail.com";
 
     } else {
@@ -145,6 +151,11 @@ public class AuthService {
     User user =
         userRepository
             .findByEmail(finalEmail)
+            .map(
+                existing -> {
+                  existing.update(finalName, finalImage);
+                  return userRepository.save(existing);
+                })
             .orElseGet(
                 () ->
                     userRepository.save(

--- a/src/main/resources/static/profile.html
+++ b/src/main/resources/static/profile.html
@@ -100,10 +100,18 @@
 
                 let pictureData = result.data.picture;
                 if (pictureData) {
-                    const fileId = String(pictureData).includes('/')
-                        ? pictureData.split('/').pop()
-                        : pictureData;
-                    updateAvatarView(fileId);
+                    if (pictureData.startsWith('http')) {
+
+                        const img = document.getElementById('avatarImg');
+                        const plus = document.getElementById('avatarPlus');
+                        img.src = pictureData;
+                        img.style.display = 'block';
+                        plus.style.display = 'none';
+                    } else {
+
+                        const fileId = pictureData.split('/').pop();
+                        updateAvatarView(fileId);
+                    }
                 }
             }
         } catch (e) {


### PR DESCRIPTION
## ❓이슈
- close #111

## :memo: Description

카카오 소셜 로그인 시 `GET /api/v1/auth/me` 응답의 `picture` 필드가 null로 반환되는 문제를 수정했습니다.

**문제 1. `AuthService.socialLogin()` 카카오 프로필 이미지 추출 누락**
- 카카오 유저 정보에서 `profile_image_url` 추출 로직이 없어 `image = null` 유지
- `kakao_account.profile.profile_image_url` 추출 로직 추가
- `properties.profile_image` fallback 처리 추가

**문제 2. 기존 유저 재로그인 시 picture 업데이트 안 됨**
- 기존 유저가 카카오로 다시 로그인할 때 조회만 하고 picture 업데이트 없음
- `user.update()` 호출하여 name, picture 최신화하도록 수정

**문제 3. `profile.html` 외부 이미지 URL 처리 누락**
- 카카오 picture URL(`http://k.kakaocdn.net/...`)을 `/api/v1/files/{id}` 형식으로 파싱하여 500 에러 발생
- `http`로 시작하는 외부 URL은 그대로 사용하도록 분기 처리

<!-- 테스트 스크린샷 여기에 추가해주세요 -->
<img width="689" height="321" alt="image" src="https://github.com/user-attachments/assets/75773ce3-09b0-469a-980a-bf320a62a35b" />

## :cyclone: PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 카카오 로그인 후 `GET /api/v1/auth/me` 응답에서 `picture` 필드 `k.kakaocdn.net` URL 정상 반환 확인
- [x] `profile.html` 카카오 프로필 이미지 정상 표시 확인