### PR TITLE
✨ feat: 영수증 응답에 amountMismatch 필드 추가

### DIFF
--- a/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptDetailDto.java
@@ -69,4 +69,7 @@ public class ReceiptDetailDto {
 
   @Schema(description = "게시자 프로필 사진", nullable = true)
   private String userPicture;
+
+  @Schema(description = "금액 불일치 여부", example = "false")
+  private boolean amountMismatch;
 }

--- a/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
+++ b/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
@@ -66,4 +66,7 @@ public class UploadReceiptResponse {
 
   @Schema(description = "AI 추천 반려 사유", nullable = true)
   private String aiReason;
+
+  @Schema(description = "금액 불일치 여부", example = "false")
+  private boolean amountMismatch;
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -616,6 +616,11 @@ public class ReceiptService {
     String ownerPicture =
         userRepository.findById(receipt.getUserId()).map(u -> u.getPicture()).orElse(null);
     List<ReceiptItem> items = receiptItemRepository.findAllByReceiptId(id);
+    boolean amountMismatch =
+        calculateAmountMismatch(
+            items,
+            receipt.getTotalAmount(),
+            receipt.getDiscountAmount() != null ? receipt.getDiscountAmount() : 0);
 
     return new ReceiptDetailDto(
         receipt.getId(),
@@ -636,7 +641,8 @@ public class ReceiptService {
         receipt.getDiscountAmount(),
         receipt.getAiReason(),
         receipt.getCategory(),
-        ownerPicture);
+        ownerPicture,
+        amountMismatch);
   }
 
   public ReceiptActionResponseDto toReceiptActionResponse(Receipt receipt) {
@@ -657,6 +663,22 @@ public class ReceiptService {
         .tags(receipt.getTags())
         .createdAt(receipt.getCreatedAt())
         .build();
+  }
+
+  private boolean calculateAmountMismatch(
+      List<ReceiptItem> items, int totalAmount, int discountAmount) {
+    if (items == null || items.isEmpty() || totalAmount <= 0) return false;
+
+    int itemsTotal = items.stream().mapToInt(item -> item.getQuantity() * item.getPrice()).sum();
+
+    if (itemsTotal <= 0) return false;
+
+    boolean hasDiscount = discountAmount > 0;
+    double toleranceRate = hasDiscount ? 0.03 : 0.01;
+    int tolerance = Math.max(1, (int) (totalAmount * toleranceRate));
+    int expectedTotal = itemsTotal - discountAmount;
+
+    return Math.abs(expectedTotal - totalAmount) > tolerance;
   }
 
   private UploadReceiptResponse toUploadReceiptResponse(Receipt receipt, boolean isDuplicate) {
@@ -680,6 +702,11 @@ public class ReceiptService {
         .inappropriateReasons(receipt.getInappropriateReasons())
         .discountAmount(receipt.getDiscountAmount())
         .aiReason(receipt.getAiReason())
+        .amountMismatch(
+            calculateAmountMismatch(
+                receiptItemRepository.findAllByReceiptId(receipt.getId()),
+                receipt.getTotalAmount(),
+                receipt.getDiscountAmount() != null ? receipt.getDiscountAmount() : 0))
         .build();
   }
 


### PR DESCRIPTION
## ❓이슈
- close #113

## :memo: Description

영수증 응답에 금액 불일치 여부를 나타내는 `amountMismatch` 필드를 추가했습니다.

프론트에서 items 합산값과 totalAmount가 다른 경우를 판단하려면 직접 계산 로직을 구현해야 했는데, 백엔드에서 계산한 결과를 `amountMismatch` 필드로 반환하여 해결했습니다.

**추가된 API 응답 필드**
- `amountMismatch: boolean`
  - `true`: 금액 불일치 (허용 오차 초과)
  - `false`: 금액 일치 (정상)

**계산 방식**

① items 합산: `itemsTotal = Σ(price * quantity)`

② 예상 결제금액 계산: `expectedTotal = itemsTotal - discountAmount`

③ 허용 오차 계산
- `discountAmount > 0` 이면 → `tolerance = max(1, totalAmount * 3%)`
- `discountAmount = 0` 이면 → `tolerance = max(1, totalAmount * 1%)`

④ 불일치 판정: `abs(expectedTotal - totalAmount) > tolerance` → `amountMismatch: true`

**실제 예시**

정상 케이스 (한돈담):
- itemsTotal = 25×7,000 + 4×3,000 + 4×1,000 + 13×2,000 = 217,000
- discountAmount = 0 → expectedTotal = 217,000
- tolerance = max(1, 217,000 × 1%) = 2,170
- abs(217,000 - 217,000) = 0 > 2,170? → **false**

금액 불일치 케이스 (바나프레소):
- itemsTotal = 1 × 2,000 = 2,000
- discountAmount = 500 → expectedTotal = 1,500
- tolerance = max(1, 2,000 × 3%) = 60 ← 할인 있으니 3%
- abs(1,500 - 2,000) = 500 > 60? → **true**

**추가된 응답**
- `GET /api/v1/receipts/{id}` (ReceiptDetailDto)
- `POST /api/v1/receipts/upload` (UploadReceiptResponse)

① amountMismatch = false 케이스 (정상 영수증)
<img width="493" height="517" alt="image" src="https://github.com/user-attachments/assets/4c83b808-0e20-44e8-87a9-137349bf55cd" />

② amountMismatch = true 케이스 (금액 불일치)
<img width="435" height="513" alt="image" src="https://github.com/user-attachments/assets/76ef7c1a-16e3-47be-a9a2-a54af1346e3d" />

## :cyclone: PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] `GET /api/v1/receipts/{id}` 정상 영수증 `amountMismatch: false` 확인
- [x] `GET /api/v1/receipts/{id}` 금액 불일치 영수증 `amountMismatch: true` 확인