### PR TITLE
✨ feat: 영수증 단일 업로드/저장확정 응답에 items, userPicture 필드 추가

### DIFF
--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -311,34 +311,41 @@ public class ReceiptController {
                         name = "업로드 성공",
                         value =
                             """
-                                          {
-                                            "success": true,
-                                            "data": {
-                                              "id": 1,
-                                              "status": "ANALYZING",
-                                              "systemErrorCode": null,
-                                              "storeName": "스타벅스 상명대점",
-                                              "tradeAt": "2026-03-24T10:36:08",
-                                              "totalAmount": 5500,
-                                              "nightTime": false,
-                                              "rejectionReason": null,
-                                              "approvedAt": null,
-                                              "tax": 500,
-                                              "confidence": 0.91,
-                                              "fileAssetId": 1,
-                                              "tags": [],
-                                              "createdAt": "2026-03-24T10:36:08",
-                                              "duplicate": false,
-                                              "inappropriateReasons": [],
-                                              "discountAmount": 0,
-                                              "aiReason": "정상 영수증으로 판단됨"
-                                            },
-                                            "meta": {
-                                              "timestamp": "2026-03-24T19:36:08.117",
-                                              "traceId": "receipt-upload-1234"
-                                            }
-                                          }
-                                          """)))
+    {
+      "success": true,
+      "data": {
+        "id": 1,
+        "status": "ANALYZING",
+        "systemErrorCode": null,
+        "storeName": "스타벅스 상명대점",
+        "tradeAt": "2026-03-24T10:36:08",
+        "totalAmount": 5500,
+        "nightTime": false,
+        "rejectionReason": null,
+        "approvedAt": null,
+        "tax": 500,
+        "confidence": 0.91,
+        "fileAssetId": 1,
+        "tags": [],
+        "createdAt": "2026-03-24T10:36:08",
+        "duplicate": false,
+        "inappropriateReasons": [],
+        "discountAmount": 0,
+        "aiReason": "정상 영수증으로 판단됨",
+        "amountMismatch": false,
+        "items": [
+          {
+            "id": 1,
+            "receiptId": 1,
+            "name": "아메리카노",
+            "quantity": 1,
+            "price": 5500
+          }
+        ],
+        "userPicture": null
+      }
+    }
+    """)))
   })
   @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ApiResponse<UploadReceiptResponse>> upload(
@@ -628,30 +635,36 @@ public class ReceiptController {
                         name = "저장 확정 성공",
                         value =
                             """
-                                          {
-                                            "success": true,
-                                            "data": {
-                                              "id": 1,
-                                              "status": "WAITING",
-                                              "systemErrorCode": null,
-                                              "storeName": "스타벅스 상명대점",
-                                              "tradeAt": "2026-03-24T10:36:08",
-                                              "totalAmount": 5500,
-                                              "nightTime": false,
-                                              "rejectionReason": null,
-                                              "approvedAt": null,
-                                              "tax": 500,
-                                              "confidence": 0.91,
-                                              "fileAssetId": 1,
-                                              "tags": [],
-                                              "createdAt": "2026-03-24T10:36:08"
-                                            },
-                                            "meta": {
-                                              "timestamp": "2026-03-24T19:36:08.117",
-                                              "traceId": "receipt-confirm-1234"
-                                            }
-                                          }
-                                          """)))
+    {
+      "success": true,
+      "data": {
+        "id": 1,
+        "status": "WAITING",
+        "systemErrorCode": null,
+        "storeName": "스타벅스 상명대점",
+        "tradeAt": "2026-03-24T10:36:08",
+        "totalAmount": 5500,
+        "nightTime": false,
+        "rejectionReason": null,
+        "approvedAt": null,
+        "tax": 500,
+        "confidence": 0.91,
+        "fileAssetId": 1,
+        "tags": [],
+        "createdAt": "2026-03-24T10:36:08",
+        "items": [
+          {
+            "id": 1,
+            "receiptId": 1,
+            "name": "아메리카노",
+            "quantity": 1,
+            "price": 5500
+          }
+        ],
+        "userPicture": null
+      }
+    }
+    """)))
   })
   @PatchMapping("/{id}/confirm")
   public ResponseEntity<ApiResponse<ReceiptActionResponseDto>> confirmReceipt(

--- a/src/main/java/com/example/backend/dto/ReceiptActionResponseDto.java
+++ b/src/main/java/com/example/backend/dto/ReceiptActionResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.backend.dto;
 
+import com.example.backend.entity.ReceiptItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -54,4 +55,10 @@ public class ReceiptActionResponseDto {
 
   @Schema(description = "생성 시각", example = "2026-03-23T13:44:34", nullable = true)
   private LocalDateTime createdAt;
+
+  @Schema(description = "상품 목록", nullable = true)
+  private List<ReceiptItem> items;
+
+  @Schema(description = "게시자 프로필 사진", nullable = true)
+  private String userPicture;
 }

--- a/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
+++ b/src/main/java/com/example/backend/dto/UploadReceiptResponse.java
@@ -1,5 +1,6 @@
 package com.example.backend.dto;
 
+import com.example.backend.entity.ReceiptItem;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -69,4 +70,10 @@ public class UploadReceiptResponse {
 
   @Schema(description = "금액 불일치 여부", example = "false")
   private boolean amountMismatch;
+
+  @Schema(description = "상품 목록", nullable = true)
+  private List<ReceiptItem> items;
+
+  @Schema(description = "게시자 프로필 사진", nullable = true)
+  private String userPicture;
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -646,6 +646,10 @@ public class ReceiptService {
   }
 
   public ReceiptActionResponseDto toReceiptActionResponse(Receipt receipt) {
+    List<ReceiptItem> items = receiptItemRepository.findAllByReceiptId(receipt.getId());
+    String userPicture =
+        userRepository.findById(receipt.getUserId()).map(u -> u.getPicture()).orElse(null);
+
     return ReceiptActionResponseDto.builder()
         .id(receipt.getId())
         .status(receipt.getStatus() != null ? receipt.getStatus().name() : null)
@@ -662,6 +666,8 @@ public class ReceiptService {
         .fileAssetId(receipt.getFileAssetId())
         .tags(receipt.getTags())
         .createdAt(receipt.getCreatedAt())
+        .items(items)
+        .userPicture(userPicture)
         .build();
   }
 
@@ -682,6 +688,10 @@ public class ReceiptService {
   }
 
   private UploadReceiptResponse toUploadReceiptResponse(Receipt receipt, boolean isDuplicate) {
+    List<ReceiptItem> items = receiptItemRepository.findAllByReceiptId(receipt.getId());
+    String userPicture =
+        userRepository.findById(receipt.getUserId()).map(u -> u.getPicture()).orElse(null);
+
     return UploadReceiptResponse.builder()
         .id(receipt.getId())
         .status(receipt.getStatus() != null ? receipt.getStatus().name() : null)
@@ -704,9 +714,11 @@ public class ReceiptService {
         .aiReason(receipt.getAiReason())
         .amountMismatch(
             calculateAmountMismatch(
-                receiptItemRepository.findAllByReceiptId(receipt.getId()),
+                items,
                 receipt.getTotalAmount(),
                 receipt.getDiscountAmount() != null ? receipt.getDiscountAmount() : 0))
+        .items(items)
+        .userPicture(userPicture)
         .build();
   }
 


### PR DESCRIPTION
## ❓이슈
- close #115

## :memo: Description

영수증 업로드(`POST /upload`)와 저장확정(`PATCH /{id}/confirm`) 응답에
`items`와 `userPicture` 필드가 없어서
업로드 직후 상세 화면에서 상품 목록과 게시자 프로필 사진을 표시하려면
`GET /{id}` API를 추가로 호출해야 하는 문제가 있었습니다.

두 필드를 추가하여 별도 조회 없이 바로 표시할 수 있도록 수정했습니다.

**변경 1. `ReceiptActionResponseDto.java`**
- `items`: 상품 목록 추가
- `userPicture`: 게시자 프로필 사진 추가

**변경 2. `UploadReceiptResponse.java`**
- `items`: 상품 목록 추가
- `userPicture`: 게시자 프로필 사진 추가

**변경 3. `ReceiptService.java`**
- `toReceiptActionResponse()`: items, userPicture 조회 및 반환 추가
- `toUploadReceiptResponse()`: items, userPicture 조회 및 반환 추가

**변경 4. `ReceiptController.java`**
- Swagger 예시값 업데이트

① POST /upload 응답 확인
<img width="706" height="591" alt="image" src="https://github.com/user-attachments/assets/c096b6ac-244e-46ce-819c-32b10408f5f7" />

② PATCH /{id}/confirm 응답 확인
<img width="711" height="591" alt="image" src="https://github.com/user-attachments/assets/71c10703-16ca-462c-a35f-39fe573dae70" />

## :cyclone: PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] `POST /upload` 응답에 items, userPicture 필드 확인
- [x] `PATCH /{id}/confirm` 응답에 items, userPicture 필드 확인