### PR TITLE
🐛 fix: 미확정 영수증 처리 개선

### DIFF
--- a/src/main/java/com/example/backend/BackendApplication.java
+++ b/src/main/java/com/example/backend/BackendApplication.java
@@ -4,9 +4,11 @@ import com.example.backend.file.StorageProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(StorageProperties.class)
+@EnableScheduling
 public class BackendApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/example/backend/controller/ReceiptController.java
+++ b/src/main/java/com/example/backend/controller/ReceiptController.java
@@ -215,7 +215,7 @@ public class ReceiptController {
     }
 
     try {
-      List<Receipt> receipts = receiptRepository.findAllByWorkspaceId(workspaceId);
+      List<Receipt> receipts = receiptRepository.findConfirmedByWorkspaceId(workspaceId);
       byte[] out = excelExportService.generateExcel(receipts, workspaceId);
 
       auditLogService.record(
@@ -569,21 +569,21 @@ public class ReceiptController {
                         name = "통계 조회 성공",
                         value =
                             """
-                                          {
-                                            "success": true,
-                                            "data": {
-                                              "totalCount": 10,
-                                              "approvedCount": 2,
-                                              "rejectedCount": 1,
-                                              "pendingCount": 7,
-                                              "totalAmount": 551160
-                                            },
-                                            "meta": {
-                                              "timestamp": "2026-03-24T19:36:08.117",
-                                              "traceId": "receipt-stats-1234"
-                                            }
-                                          }
-                                          """)))
+                                {
+                                  "success": true,
+                                  "data": {
+                                    "totalCount": 3,
+                                    "approvedCount": 1,
+                                    "rejectedCount": 1,
+                                    "pendingCount": 1,
+                                    "totalAmount": 219000
+                                  },
+                                  "meta": {
+                                    "timestamp": "2026-03-24T19:36:08.117",
+                                    "traceId": "receipt-stats-1234"
+                                  }
+                                }
+                                """)))
   })
   @GetMapping("/stats")
   public ResponseEntity<ApiResponse<Map<String, Object>>> getStats(@RequestParam Long workspaceId) {

--- a/src/main/java/com/example/backend/repository/ReceiptRepository.java
+++ b/src/main/java/com/example/backend/repository/ReceiptRepository.java
@@ -30,6 +30,7 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
   @Query(
       "SELECT r FROM Receipt r "
           + "WHERE r.workspaceId = :workspaceId "
+          + "AND r.status NOT IN ('ANALYZING', 'NEED_MANUAL') "
           + "AND (:storeName IS NULL OR LOWER(r.storeName) LIKE LOWER(CONCAT('%', :storeName, '%'))) "
           + "AND (:userId IS NULL OR r.userId = :userId) "
           + "AND (:status IS NULL OR r.status = :status)")
@@ -46,11 +47,11 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
 
   @Query(
       "SELECT "
-          + "count(r) as totalCount, "
-          + "sum(case when r.status = 'WAITING' or r.status = 'NEED_MANUAL' then 1 else 0 end) as pendingCount, "
+          + "sum(case when r.status = 'WAITING' or r.status = 'APPROVED' or r.status = 'REJECTED' then 1 else 0 end) as totalCount, "
+          + "sum(case when r.status = 'WAITING' then 1 else 0 end) as pendingCount, "
           + "sum(case when r.status = 'APPROVED' then 1 else 0 end) as approvedCount, "
           + "sum(case when r.status = 'REJECTED' then 1 else 0 end) as rejectedCount, "
-          + "sum(r.totalAmount) as totalAmount "
+          + "sum(case when r.status = 'WAITING' or r.status = 'APPROVED' or r.status = 'REJECTED' then r.totalAmount else 0 end) as totalAmount "
           + "FROM Receipt r WHERE r.workspaceId = :workspaceId")
   java.util.Map<String, Object> getWorkspaceStats(@Param("workspaceId") Long workspaceId);
 
@@ -66,4 +67,16 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
       @Param("from") LocalDateTime from,
       @Param("to") LocalDateTime to,
       @Param("excludeId") Long excludeId);
+
+  @Query(
+      "SELECT r FROM Receipt r "
+          + "WHERE (r.status = 'ANALYZING' OR r.status = 'NEED_MANUAL') "
+          + "AND r.createdAt < :threshold")
+  List<Receipt> findAbandonedReceipts(@Param("threshold") LocalDateTime threshold);
+
+  @Query(
+      "SELECT r FROM Receipt r "
+          + "WHERE r.workspaceId = :workspaceId "
+          + "AND r.status NOT IN ('ANALYZING', 'NEED_MANUAL')")
+  List<Receipt> findConfirmedByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
+++ b/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
@@ -1,4 +1,41 @@
 package com.example.backend.service;
 
+import com.example.backend.entity.Receipt;
+import com.example.backend.repository.ReceiptItemRepository;
+import com.example.backend.repository.ReceiptRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class ReceiptCleanupScheduler {
+
+  private final ReceiptRepository receiptRepository;
+  private final ReceiptItemRepository receiptItemRepository;
+
+  @Transactional
+  @Scheduled(fixedDelay = 10000)
+  public void deleteAbandonedReceipts() {
+    LocalDateTime threshold = LocalDateTime.now();
+
+    List<Receipt> abandoned = receiptRepository.findAbandonedReceipts(threshold);
+
+    if (abandoned.isEmpty()) return;
+
+    log.info("=== [스케줄러] 미확정 영수증 {}건 삭제 시작", abandoned.size());
+
+    for (Receipt receipt : abandoned) {
+      receiptItemRepository.deleteAll(receiptItemRepository.findAllByReceiptId(receipt.getId()));
+      receiptRepository.delete(receipt);
+      log.info("=== [스케줄러] 영수증 삭제 완료: id={}", receipt.getId());
+    }
+
+    log.info("=== [스케줄러] 미확정 영수증 삭제 완료");
+  }
 }

--- a/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
+++ b/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
@@ -20,9 +20,9 @@ public class ReceiptCleanupScheduler {
   private final ReceiptItemRepository receiptItemRepository;
 
   @Transactional
-  @Scheduled(fixedDelay = 10000)
+  @Scheduled(fixedDelay = 300000)
   public void deleteAbandonedReceipts() {
-    LocalDateTime threshold = LocalDateTime.now();
+    LocalDateTime threshold = LocalDateTime.now().minusMinutes(10);
 
     List<Receipt> abandoned = receiptRepository.findAbandonedReceipts(threshold);
 

--- a/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
+++ b/src/main/java/com/example/backend/service/ReceiptCleanupScheduler.java
@@ -1,0 +1,4 @@
+package com.example.backend.service;
+
+public class ReceiptCleanupScheduler {
+}

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -106,12 +106,28 @@ public class ReceiptService {
       Optional<Receipt> existingByHash =
           receiptRepository.findByFileHashAndWorkspaceId(fileHash, workspaceId);
       if (existingByHash.isPresent()) {
-        return toUploadReceiptResponse(existingByHash.get(), true);
+        Receipt existing = existingByHash.get();
+        if (existing.getStatus() == ReceiptStatus.ANALYZING
+            || existing.getStatus() == ReceiptStatus.NEED_MANUAL) {
+          receiptItemRepository.deleteAll(
+              receiptItemRepository.findAllByReceiptId(existing.getId()));
+          receiptRepository.delete(existing);
+        } else {
+          return toUploadReceiptResponse(existing, true);
+        }
       }
 
       Optional<Receipt> existingByKey = receiptRepository.findByIdempotencyKey(idempotencyKey);
       if (existingByKey.isPresent()) {
-        return toUploadReceiptResponse(existingByKey.get(), true);
+        Receipt existing = existingByKey.get();
+        if (existing.getStatus() == ReceiptStatus.ANALYZING
+            || existing.getStatus() == ReceiptStatus.NEED_MANUAL) {
+          receiptItemRepository.deleteAll(
+              receiptItemRepository.findAllByReceiptId(existing.getId()));
+          receiptRepository.delete(existing);
+        } else {
+          return toUploadReceiptResponse(existing, true);
+        }
       }
 
       AnalyzedReceipt analyzedReceipt = analyzeReceipt(fileBytes, file.getContentType());


### PR DESCRIPTION
## ❓이슈
- close #117

## :memo: Description

AI 분석 후 저장 확정 전 사용자 이탈 시 발생하는 미확정 영수증 처리 문제를 개선했습니다.

---

### 📌 영수증 상태 파이프라인

업로드 후 ANALYZING 또는 NEED_MANUAL 상태로 저장되고, 저장확정(confirm) 시 WAITING으로 전환됩니다. 이후 관리자가 APPROVED 또는 REJECTED로 처리합니다.

| 상태 | 설명 |
|------|------|
| ANALYZING | 필수 필드 정상, confidence ≥ 0.7 |
| NEED_MANUAL | 필수 필드 누락 or 금액 불일치 |
| WAITING | 저장 확정 완료, 관리자 검토 대기 |
| APPROVED / REJECTED | 관리자 처리 완료 |

`ANALYZING`, `NEED_MANUAL`은 미확정 상태로, 사용자가 저장 확정 전 이탈 시 DB에 잔류할 수 있습니다.

---

### 🔧 변경 1. 목록 조회에서 미확정 영수증 제외

`findByWorkspaceIdWithFilters()` 쿼리에 아래 조건을 추가했습니다.

`AND r.status NOT IN ('ANALYZING', 'NEED_MANUAL')`

저장 확정된 영수증(WAITING/APPROVED/REJECTED)만 목록에 표시됩니다.

<img width="586" height="1016" alt="image" src="https://github.com/user-attachments/assets/303c8386-9caf-43bd-864b-ce7b83aa4a30" />
<img width="648" height="634" alt="image" src="https://github.com/user-attachments/assets/fd492799-cd62-4b13-883b-fc9840c4c038" />

---

### 🔧 변경 2. 통계(stats) totalCount/pendingCount 재설계

| 항목 | 기존 | 변경 후 |
|------|------|---------|
| totalCount | 전체 영수증 수 (미확정 포함) | WAITING + APPROVED + REJECTED |
| pendingCount | WAITING + NEED_MANUAL | WAITING만 |
| totalAmount | 전체 합산 | 확정된 영수증 합산만 |

DB에는 총 7개가 있지만 실제로는 2개만 표시됩니다. 나머지 5개는 재업로드 시 새로 분석되거나 스케줄러에 의해 일정 시간 후 자동 삭제됩니다.

<img width="843" height="356" alt="image" src="https://github.com/user-attachments/assets/32e3e328-3797-4a7b-9ebb-19cddb33ce22" />

---

### 🔧 변경 3. 중복 체크 로직 수정

**기존:** fileHash/idempotencyKey 중복 시 무조건 "이미 등록된 영수증" 처리

**변경 후:**

| 기존 영수증 상태 | 처리 방식 |
|----------------|----------|
| ANALYZING / NEED_MANUAL | 기존 영수증 삭제 후 새로 OCR+AI 분석 시작 |
| WAITING / APPROVED / REJECTED | "이미 등록된 영수증" 처리 유지 |

강제 이탈 후 같은 영수증 재업로드 시 정상 동작을 보장합니다.

---

### 🔧 변경 4. 미확정 영수증 자동 삭제 스케줄러 추가

`ReceiptCleanupScheduler.java` 신규 생성

| 항목 | 내용 |
|------|------|
| 실행 주기 | 5분마다 |
| 삭제 기준 | createdAt 기준 10분 이상 경과한 ANALYZING/NEED_MANUAL 영수증 |
| 자동 삭제 보장 시간 | 최대 10~15분 내 |

<img width="1014" height="314" alt="image" src="https://github.com/user-attachments/assets/6a706186-30c1-4da4-9a89-e8c25d632dde" />

---

### 🔧 변경 5. 엑셀 다운로드에서 미확정 영수증 제외

`findAllByWorkspaceId()` → `findConfirmedByWorkspaceId()`로 변경하여
전체 다운로드 시 WAITING/APPROVED/REJECTED만 포함됩니다.

---

### 📊 테스트 결과 (workspace_id=3 기준)

**DB 현황:** ANALYZING 1건, NEED_MANUAL 1건, APPROVED 1건, REJECTED 1건 (총 4건)

| API | 항목 | 결과 |
|-----|------|------|
| stats | totalCount | 2 (APPROVED + REJECTED, 미확정 제외) |
| stats | pendingCount | 0 (WAITING 없음) |
| 목록 조회 | totalCount | 2 (ANALYZING/NEED_MANUAL 제외) |
| 목록 조회 | 반환 데이터 | APPROVED, REJECTED만 반환 |


## :cyclone: PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] `GET /api/v1/receipts` 목록에서 ANALYZING/NEED_MANUAL 제외 확인
- [x] `GET /api/v1/receipts/stats` totalCount/pendingCount 정확성 확인
- [x] DB 쿼리 결과와 API 응답 totalCount 일치 확인
- [x] 미확정 영수증 재업로드 시 새로 분석 시작 확인
- [x] 스케줄러 로그 및 자동 삭제 확인