### PR TITLE
🐛 fix: 영수증 이미지 파일 다운로드 인증 오류 수정

### DIFF
--- a/src/main/java/com/example/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/backend/config/JwtAuthenticationFilter.java
@@ -23,8 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-    String path = request.getRequestURI();
-    return path.startsWith("/api/v1/files/");
+    return false;
   }
 
   @Override

--- a/src/main/java/com/example/backend/file/FileController.java
+++ b/src/main/java/com/example/backend/file/FileController.java
@@ -63,12 +63,13 @@ public class FileController {
   })
   @GetMapping("/{fileId}")
   public ResponseEntity<?> download(
-      @Parameter(description = "파일 ID", example = "1") @PathVariable Long fileId)
+      @Parameter(description = "파일 ID", example = "1") @PathVariable Long fileId,
+      @Parameter(hidden = true) Authentication authentication)
       throws IOException {
 
     boolean isAdmin = false;
     boolean isDevice = false;
-    String authName = null;
+    String authName = (authentication != null) ? authentication.getName() : null;
 
     FileAssetService.LoadedFile loaded =
         service.loadForDownload(fileId, authName, isAdmin, isDevice);


### PR DESCRIPTION
## ❓이슈
- close #121

## :memo: Description

영수증 이미지 파일 다운로드 시 UNAUTHORIZED 오류가 발생하는 문제를 수정했습니다.

---

### 🔍 원인 분석

**원인 1. JWT 필터에서 파일 경로 제외**

`JwtAuthenticationFilter.shouldNotFilter()`에서 `/api/v1/files/` 경로를 JWT 필터 대상에서 제외하고 있어서 토큰을 헤더에 넣어도 인증 정보가 SecurityContext에 저장되지 않았습니다.

**원인 2. FileController에서 authName = null 고정**

`download()` 메서드에 Authentication 파라미터가 없어서 항상 `authName = null`로 처리되었습니다. RECEIPT 타입 파일은 워크스페이스 멤버 검증이 필요한데 authName이 null이라 UNAUTHORIZED가 발생했습니다.

---

### 🔧 변경 후 동작

| 파일 타입 | 인증 없이 접근 | 인증 후 접근 |
|-----------|--------------|------------|
| PROFILE | ✅ 가능 | ✅ 가능 |
| RECEIPT | ❌ UNAUTHORIZED | ✅ 워크스페이스 멤버면 가능 |

---

### 📷 테스트 결과

**GET /api/v1/files/{fileId} 파일 다운로드/조회 (영수증은 fileAssetId 값 입력)**

<img width="993" height="1499" alt="image" src="https://github.com/user-attachments/assets/674c4ead-7d07-429e-b170-92d170a0dcb5" />

---

###  프론트팀 참고사항

영수증 이미지 접근 시 반드시 Authorization 헤더에 토큰을 포함해야 합니다.

추후 작업이 복잡할 경우 PROFILE처럼 인증 없이 접근 가능하게 변경 가능합니다.

## :cyclone: PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 토큰 포함 시 영수증 이미지 접근 가능 확인
- [x] 토큰 없이 PROFILE 이미지 접근 가능 확인
- [x] 토큰 없이 RECEIPT 이미지 접근 불가 확인