### PR TITLE
🐛 fix: 상호명 변경 시 category 무관하게 유흥업소 키워드 체크

### DIFF
--- a/src/main/java/com/example/backend/service/InappropriateReasonService.java
+++ b/src/main/java/com/example/backend/service/InappropriateReasonService.java
@@ -116,32 +116,14 @@ public class InappropriateReasonService {
   }
 
   private boolean isEntertainment(String storeName, String category, List<ReceiptItem> items) {
+    if (hasEntertainmentKeyword(storeName)) return true;
+
     if (category != null) {
       String cat = category.toUpperCase();
-
-      if (cat.equals("SHOPPING")) {
-        return false;
-      }
-
-      if (cat.equals("FOOD")
-          || cat.equals("MEDICAL")
-          || cat.equals("TRANSPORT")
-          || cat.equals("ACCOMMODATION")
-          || cat.equals("OFFICE")
-          || cat.equals("EQUIPMENT")
-          || cat.equals("WELFARE")
-          || cat.equals("SERVICE")
-          || cat.equals("ACTIVITY")) {
-        return hasAlcoholOrTobacco(items);
-      }
-
-      if (cat.equals("ENTERTAINMENT")) {
-        return hasEntertainmentKeyword(storeName) || hasAlcoholOrTobacco(items);
-      }
+      if (cat.equals("SHOPPING")) return false;
     }
 
-    if (storeName == null || storeName.isBlank()) return false;
-    return hasEntertainmentKeyword(storeName) || hasAlcoholOrTobacco(items);
+    return hasAlcoholOrTobacco(items);
   }
 
   private boolean isSplitPayment(Receipt receipt, Long workspaceId) {


### PR DESCRIPTION
## ❓이슈
- close #125

## :memo: Description

상호명 변경 시 category 값에 따라
SUSPICIOUS_ENTERTAINMENT 태그가
올바르게 재평가되지 않는 버그를 수정했습니다.

---

### 📌 문제 원인

기존 isEntertainment() 로직에서
storeName에 유흥업소 키워드가 있어도
category가 FOOD 등이면 무시되는 구조였습니다.

버그 케이스:

"레스토랑" 영수증을 AI가 FOOD로 분류한 상태에서
사용자가 상호명을 "에스노래빠"로 수정 시:
- category는 여전히 FOOD
- hasAlcoholOrTobacco()만 체크
- items에 술 없으면 SUSPICIOUS_ENTERTAINMENT 추가 안 됨 

---

### 🔧 변경 내용

isEntertainment() 로직 수정

수정 전:

| category | storeName 키워드 체크 | items 주류/담배 체크 |
|---|---|---|
| FOOD/MEDICAL 등 |  안 함 |  함 |
| ENTERTAINMENT |  함 |  함 |
| SHOPPING |  안 함 |  안 함 |

수정 후:

| 조건 | 동작 |
|---|---|
| storeName에 유흥업소 키워드 있음 | 무조건 true |
| SHOPPING 카테고리 | storeName 키워드 없으면 false |
| 나머지 | items 주류/담배 체크 |

---

### 📊 수정 전/후 동작 비교

케이스 1. FOOD 카테고리에서 상호명 변경

수정 전:
- "레스토랑"(FOOD) → "에스노래빠"로 수정
- SUSPICIOUS_ENTERTAINMENT 추가 안 됨

수정 후:
- "레스토랑"(FOOD) → "에스노래빠"로 수정
- hasEntertainmentKeyword("에스노래빠") → true
- SUSPICIOUS_ENTERTAINMENT 추가

케이스 2. 유흥업소 → 일반 상호명으로 변경

수정 전/후 동일:
- "에스노래빠" → "에스레스토랑"으로 수정
- hasEntertainmentKeyword("에스레스토랑") → false
- SUSPICIOUS_ENTERTAINMENT 제거

케이스 3. SHOPPING 카테고리

수정 전/후 동일:
- storeName 키워드 없으면 false
- storeName에 "노래빠" 있으면 true

## :cyclone: PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] FOOD 카테고리에서 유흥업소 상호명으로 변경 시 태그 추가 확인
- [x] 유흥업소 상호명에서 일반 상호명으로 변경 시 태그 제거 확인
- [x] SHOPPING 카테고리 동작 확인