### PR TITLE
🐛 fix: 분할결제 상호명 정규화 개선으로 특수문자 포함 상호명 분할결제 탐지

### DIFF
--- a/src/main/java/com/example/backend/service/InappropriateReasonService.java
+++ b/src/main/java/com/example/backend/service/InappropriateReasonService.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -129,7 +130,7 @@ public class InappropriateReasonService {
   private boolean isSplitPayment(Receipt receipt, Long workspaceId) {
     if (receipt.getStoreName() == null || receipt.getTradeAt() == null) return false;
 
-    String normalizedStore = receipt.getStoreName().replaceAll("\\s+", "").toLowerCase();
+    String normalizedStore = normalize(receipt.getStoreName());
     LocalDateTime from = receipt.getTradeAt().minusMinutes(30);
     LocalDateTime to = receipt.getTradeAt().plusMinutes(30);
 
@@ -137,19 +138,22 @@ public class InappropriateReasonService {
         receiptRepository.findSplitPaymentCandidates(
             workspaceId, normalizedStore, from, to, receipt.getId());
 
-    return !nearby.isEmpty();
+    return nearby.stream().anyMatch(r -> normalize(r.getStoreName()).equals(normalizedStore));
   }
 
   private void applySplitPaymentTagToOthers(Receipt receipt, Long workspaceId) {
     if (receipt.getStoreName() == null || receipt.getTradeAt() == null) return;
 
-    String normalizedStore = receipt.getStoreName().replaceAll("\\s+", "").toLowerCase();
+    String normalizedStore = normalize(receipt.getStoreName());
     LocalDateTime from = receipt.getTradeAt().minusMinutes(30);
     LocalDateTime to = receipt.getTradeAt().plusMinutes(30);
 
     List<Receipt> others =
-        receiptRepository.findSplitPaymentCandidates(
-            workspaceId, normalizedStore, from, to, receipt.getId());
+        receiptRepository
+            .findSplitPaymentCandidates(workspaceId, normalizedStore, from, to, receipt.getId())
+            .stream()
+            .filter(r -> normalize(r.getStoreName()).equals(normalizedStore))
+            .collect(Collectors.toList());
 
     for (Receipt other : others) {
       List<String> otherReasons = new ArrayList<>(other.getInappropriateReasons());


### PR DESCRIPTION
## ❓이슈
- close #127

## :memo: Description

분할결제 탐지 시 상호명 정규화가 공백만 제거하고 있어서
특수문자가 포함된 상호명의 경우 분할결제 미탐이 발생하는 버그를 수정했습니다.

---

### 📌 문제 원인

isSplitPayment()와 applySplitPaymentTagToOthers()에서
상호명 정규화 시 공백만 제거하고 있어서
OCR이 특수문자를 포함한 상호명을 뽑으면
DB 저장값과 불일치가 발생했습니다.

실제 미탐 케이스 (162번):

| 구분 | 상호명 | 정규화 결과 |
|---|---|---|
| DB 저장값 | 부대통령뚝배기 상명대점 | 부대통령뚝배기상명대점 |
| OCR 인식값 | 부대통령뚝배기[상명대점] | 부대통령뚝배기[상명대점] |
| 비교 결과 | 불일치 → 분할결제 미탐 ❌ | |

---

### 🔧 변경 내용

isSplitPayment()와 applySplitPaymentTagToOthers()에서
normalize() 메서드를 사용하여 특수문자까지 제거합니다.

normalize()는 한글/영문/숫자만 남기고 전부 제거합니다.

Repository 쿼리는 그대로 두고
Java에서 normalize() 비교로 한번 더 필터링합니다.

수정 전 정규화 방식:

replaceAll("\\s+", "").toLowerCase() → 공백만 제거

수정 후 정규화 방식:

normalize() → 한글/영문/숫자만 남기고 특수문자 전부 제거

---

### 📊 수정 전/후 동작 비교

수정 전:
- 부대통령뚝배기[상명대점] 업로드 시
- DB의 부대통령뚝배기 상명대점과 불일치
- 분할결제 미탐 ❌

수정 후:
- 부대통령뚝배기[상명대점] → normalize() → 부대통령뚝배기상명대점
- DB의 부대통령뚝배기 상명대점 → normalize() → 부대통령뚝배기상명대점
- 일치 → 분할결제 감지 ✅

## :cyclone: PR Type

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [ ] 특수문자 포함 상호명 분할결제 탐지 확인 (OCR 재현 어려워서 전체 테스트 시 확인 예정)