### PR TITLE
🐛 fix: ocr 기반 중복 영수증 체크

### DIFF
--- a/src/main/java/com/example/backend/repository/ReceiptRepository.java
+++ b/src/main/java/com/example/backend/repository/ReceiptRepository.java
@@ -79,4 +79,17 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
           + "WHERE r.workspaceId = :workspaceId "
           + "AND r.status NOT IN ('ANALYZING', 'NEED_MANUAL')")
   List<Receipt> findConfirmedByWorkspaceId(@Param("workspaceId") Long workspaceId);
+
+  @Query(
+      "SELECT r FROM Receipt r "
+          + "WHERE r.workspaceId = :workspaceId "
+          + "AND LOWER(REPLACE(r.storeName, ' ', '')) = :normalizedStore "
+          + "AND r.totalAmount = :totalAmount "
+          + "AND r.tradeAt = :tradeAt "
+          + "AND r.status NOT IN ('ANALYZING', 'NEED_MANUAL')")
+  List<Receipt> findByContentDuplicate(
+      @Param("workspaceId") Long workspaceId,
+      @Param("normalizedStore") String normalizedStore,
+      @Param("totalAmount") int totalAmount,
+      @Param("tradeAt") LocalDateTime tradeAt);
 }

--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -132,6 +132,23 @@ public class ReceiptService {
 
       AnalyzedReceipt analyzedReceipt = analyzeReceipt(fileBytes, file.getContentType());
       validateAnalyzedReceipt(analyzedReceipt);
+
+      if (analyzedReceipt.storeName() != null
+          && !analyzedReceipt.storeName().isBlank()
+          && analyzedReceipt.tradeAt() != null) {
+        String normalizedStore = analyzedReceipt.storeName().replaceAll("\\s+", "").toLowerCase();
+        List<Receipt> contentDuplicates =
+            receiptRepository.findByContentDuplicate(
+                workspaceId,
+                normalizedStore,
+                analyzedReceipt.totalAmount(),
+                analyzedReceipt.tradeAt());
+        if (!contentDuplicates.isEmpty()) {
+          log.info("=== OCR 기반 중복 영수증 감지: {}", analyzedReceipt.storeName());
+          return toUploadReceiptResponse(contentDuplicates.get(0), true);
+        }
+      }
+
       SavedReceiptFile savedReceiptFile = saveReceiptFile(file, userId, workspaceId);
 
       Receipt receipt;


### PR DESCRIPTION
## ❓이슈
- close #131

## :memo: Description

현재 중복 영수증 체크는 MD5 파일 해시로만 수행하고 있어서
같은 영수증을 다른 폰으로 찍어서 업로드하면 중복 체크를 통과하는 문제를 개선했습니다.

---

### 📌 문제 원인

현재 중복 체크:
- MD5 파일 해시로만 체크
- 완전히 동일한 파일만 필터링
- 다른 폰으로 찍으면 파일이 달라서 통과

---

### 🔧 변경 내용

OCR 분석 완료 후 storeName + totalAmount + tradeAt 조합으로 중복 체크 추가

중복 판단 조건:
- 같은 워크스페이스
- 동일 상호명 (공백 제거 + 소문자 변환 후 비교)
- 동일 결제금액
- 동일 결제일시
- 확정된 영수증(WAITING/APPROVED/REJECTED)만 대상

---

### 📊 수정 전/후 동작 비교

수정 전:
- A가 영수증 업로드 후 저장 확정
- B가 같은 영수증 다른 폰으로 업로드
- 파일 해시 다름 → 중복 체크 통과 ❌
- 같은 영수증 두 번 등록됨

수정 후:
- A가 영수증 업로드 후 저장 확정
- B가 같은 영수증 다른 폰으로 업로드
- OCR 분석 완료 후 storeName + totalAmount + tradeAt 비교
- 일치 → duplicate: true 반환 ✅
- 프론트: 기존 이미 등록된 영수증 알림 표시 ✅
- 프론트 코드 수정 없음 ✅

---

### ⚠️ 주의사항

OCR 오인식으로 storeName이 다르게 추출되면 통과될 수 있습니다.
완전한 해결은 아니지만 대부분의 케이스를 감지할 수 있습니다.

## :cyclone: PR Type

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist
- [x] Branch Convention 확인
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist
- [x] 로컬 작동 확인
- [x] 동일 영수증 재업로드 시 duplicate: true 반환 확인
- [x] 다른 영수증 업로드 시 정상 등록 확인