### PR TITLE
🐛 fix: 영수증 OCR 인식 범위 확대 및 0원 결제 처리 오류 수정

### DIFF
--- a/src/main/java/com/example/backend/service/ReceiptService.java
+++ b/src/main/java/com/example/backend/service/ReceiptService.java
@@ -67,11 +67,9 @@ public class ReceiptService {
 
   public Long getCurrentUserId() {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
     if (auth == null || auth.getName() == null) {
       throw new BusinessException(ErrorCode.UNAUTHORIZED);
     }
-
     return userRepository
         .findByEmail(auth.getName())
         .orElseThrow(() -> new BusinessException(ErrorCode.UNAUTHORIZED))
@@ -81,7 +79,6 @@ public class ReceiptService {
   private boolean isAdmin() {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     if (auth == null) return false;
-
     return auth.getAuthorities().stream().anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
   }
 
@@ -166,18 +163,15 @@ public class ReceiptService {
                     .build());
       } catch (DataIntegrityViolationException e) {
         log.warn("영수증 중복 저장 충돌 발생. 기존 데이터 반환", e);
-
         Optional<Receipt> duplicateByHash =
             receiptRepository.findByFileHashAndWorkspaceId(fileHash, workspaceId);
         if (duplicateByHash.isPresent()) {
           return toUploadReceiptResponse(duplicateByHash.get(), true);
         }
-
         Optional<Receipt> duplicateByKey = receiptRepository.findByIdempotencyKey(idempotencyKey);
         if (duplicateByKey.isPresent()) {
           return toUploadReceiptResponse(duplicateByKey.get(), true);
         }
-
         throw e;
       }
 
@@ -286,15 +280,12 @@ public class ReceiptService {
           boolean hasDiscount = discountAmount > 0;
           double toleranceRate = hasDiscount ? 0.03 : 0.01;
           int tolerance = Math.max(1, (int) (totalAmount * toleranceRate));
-
           int expectedTotal = itemsTotal - discountAmount;
           boolean amountMismatch = Math.abs(expectedTotal - totalAmount) > tolerance;
 
           if (amountMismatch) {
             log.warn(
-                "=== [금액검증] items합계({}) - discount({}) = {}"
-                    + " / totalAmount({}) / 허용오차({}, {}%)"
-                    + " → NEED_MANUAL 유도",
+                "=== [금액검증] items합계({}) - discount({}) = {} / totalAmount({}) / 허용오차({}, {}%) → NEED_MANUAL 유도",
                 itemsTotal,
                 discountAmount,
                 expectedTotal,
@@ -306,7 +297,7 @@ public class ReceiptService {
         }
       }
 
-      boolean hasCriticalMissing = storeName.isBlank() || totalAmount <= 0 || tradeAt == null;
+      boolean hasCriticalMissing = storeName.isBlank() || totalAmount < 0 || tradeAt == null;
 
       ReceiptStatus nextStatus =
           (!hasCriticalMissing && confidence >= 0.7)
@@ -341,19 +332,16 @@ public class ReceiptService {
         analyzedReceipt.storeName() != null
             && !analyzedReceipt.storeName().isBlank()
             && !"알 수 없는 상호".equals(analyzedReceipt.storeName());
-    boolean hasPositiveAmount = analyzedReceipt.totalAmount() > 0;
+    boolean hasAmount = analyzedReceipt.totalAmount() >= 0;
     boolean hasReceiptKeyword = containsReceiptKeyword(analyzedReceipt.fullText());
 
-    if (!hasRawText || (!hasStoreName && !hasPositiveAmount) || !hasReceiptKeyword) {
+    if (!hasRawText || !hasReceiptKeyword || (!hasStoreName && !hasAmount)) {
       throw ErrorCode.VALIDATION_FAILED.toException("영수증으로 인식되지 않은 이미지입니다.");
     }
   }
 
   private boolean containsReceiptKeyword(String fullText) {
-    if (fullText == null || fullText.isBlank()) {
-      return false;
-    }
-
+    if (fullText == null || fullText.isBlank()) return false;
     String normalized = fullText.replaceAll("\\s+", "").toLowerCase();
     return normalized.contains("합계")
         || normalized.contains("총액")
@@ -364,7 +352,18 @@ public class ReceiptService {
         || normalized.contains("부가세")
         || normalized.contains("현금영수증")
         || normalized.contains("receipt")
-        || normalized.contains("total");
+        || normalized.contains("total")
+        || normalized.contains("주문금액")
+        || normalized.contains("결제금액")
+        || normalized.contains("결제일")
+        || normalized.contains("배달팁")
+        || normalized.contains("주문서")
+        || normalized.contains("주차")
+        || normalized.contains("입차")
+        || normalized.contains("출차")
+        || normalized.contains("영수증")
+        || normalized.contains("청구")
+        || normalized.contains("사업자");
   }
 
   private Receipt applyAnalyzedReceipt(Receipt receipt, AnalyzedReceipt analyzedReceipt) {
@@ -576,7 +575,6 @@ public class ReceiptService {
         r -> {
           String ownerName =
               userRepository.findById(r.getUserId()).map(u -> u.getName()).orElse("알 수 없음");
-
           return new ReceiptSummaryDto(
               r.getId(),
               r.getStoreName(),
@@ -668,7 +666,11 @@ public class ReceiptService {
             file -> {
               try {
                 return uploadAndProcess("multi-" + UUID.randomUUID(), file, workspaceId);
+              } catch (BusinessException e) {
+                log.warn("=== 영수증 처리 실패 [{}]: {}", file.getOriginalFilename(), e.getMessage());
+                return null;
               } catch (Exception e) {
+                log.error("=== 영수증 처리 중 예외 [{}]", file.getOriginalFilename(), e);
                 return null;
               }
             })
@@ -812,16 +814,12 @@ public class ReceiptService {
   private boolean calculateAmountMismatch(
       List<ReceiptItem> items, int totalAmount, int discountAmount) {
     if (items == null || items.isEmpty() || totalAmount <= 0) return false;
-
     int itemsTotal = items.stream().mapToInt(item -> item.getQuantity() * item.getPrice()).sum();
-
     if (itemsTotal <= 0) return false;
-
     boolean hasDiscount = discountAmount > 0;
     double toleranceRate = hasDiscount ? 0.03 : 0.01;
     int tolerance = Math.max(1, (int) (totalAmount * toleranceRate));
     int expectedTotal = itemsTotal - discountAmount;
-
     return Math.abs(expectedTotal - totalAmount) > tolerance;
   }
 


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #136 

## :memo: Description

**문제 상황**
기존 containsReceiptKeyword의 키워드가 카드 매출전표 기준으로만 구성되어 있어 배달 주문서, 주차비, 카페 주문서 등 다양한 유형의 영수증이 키워드 미매칭으로 인해 정상 영수증임에도 업로드 실패하는 문제 발생. 또한 전액 할인으로 결제금액이 0원인 영수증이 totalAmount > 0 조건에 걸려 업로드 실패하는 문제도 존재.

**원인 분석**
containsReceiptKeyword 키워드가 합계, 카드, 승인 등 10개로 한정되어 있어 배달/주차 영수증 미인식
validateAnalyzedReceipt의 totalAmount > 0 조건이 전액 할인 영수증을 차단
uploadMultiple에서 예외 발생 시 로그 없이 null 반환하여 실패 원인 추적 불가

**변경 사항**
 containsReceiptKeyword 키워드 11개 추가 (주문금액, 결제금액, 결제일, 배달팁, 주문서, 주차, 입차, 출차, 영수증, 청구, 사업자)
 validateAnalyzedReceipt totalAmount 조건 > 0 → >= 0 수정
 uploadMultiple 예외 처리 로그 추가

**테스트**
영수증으로 인식 안되던 배달 주문전표, 영풍문고, 이마트 주차비, 쿠팡이츠, 팀홀튼 영수증 5종 정상 분석 확인


## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
- [x] 스웨거 테스트 확인
- [x] 프론트 테스트 확인
